### PR TITLE
Fix S3 sub-route 404s with trailingSlash export

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -56,6 +56,10 @@ const nextConfig: NextConfig = {
   // Static HTML export to S3. See CONTENTFUL.md / SECURITY.md — content is
   // fetched at build time and there are no server/runtime features.
   output: "export",
+  // Emit each route as <route>/index.html (not <route>.html) so the S3 website
+  // endpoint resolves clean URLs like /travel/ -> travel/index.html. Without
+  // this, sub-routes 404 on S3 (it doesn't map /travel to travel.html).
+  trailingSlash: true,
   images: {
     // Next's default image optimizer needs a running server, which a static
     // export doesn't have. Serve the Contentful-hosted images as-is (they're


### PR DESCRIPTION
## Problem
After cutover, the homepage served fine but every sub-route (`/travel/`, city pages) returned 404. Next's static export emitted flat `travel.html` files, but the S3 website endpoint resolves `/travel/` from `travel/index.html`.

## Fix
`trailingSlash: true` in `next.config.ts` — export now emits `<route>/index.html` folders that S3 resolves for clean URLs. Verified locally: `out/travel/index.html` is produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)