### PR TITLE
Rename project to maxharding4

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -9,7 +9,7 @@ Project: **Personal Site** (`aa387dca-a9c0-4a77-b870-6a5673f0d3f8`) — https://
   `globals.css` → `@import "tailwindcss"` that esbuild can't resolve, plus all the
   Contentful/server code). Instead `cfg.entry = .design-sync/ds-entry.tsx` re-exports ONLY the
   scoped reusable components as named exports. With `--entry` set, `PKG_DIR` resolves to the repo
-  root — no `node_modules/new-site` self-symlink is needed (an early attempt used one; removed).
+  root — no `node_modules/maxharding4` self-symlink is needed (an early attempt used one; removed).
 - **`next/link` / `next/image` are aliased to render-safe shims** (`.design-sync/shims/`) via
   `.design-sync/tsconfig.bundle.json` (`cfg.tsconfig`). That tsconfig is bundle-only — it is NOT
   the real Next build config. The shims render `<a>` / `<img>` so cards render without a Next router.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,5 +1,5 @@
 {
-  "pkg": "new-site",
+  "pkg": "maxharding4",
   "globalName": "PersonalSite",
   "projectId": "aa387dca-a9c0-4a77-b870-6a5673f0d3f8",
   "shape": "package",

--- a/.design-sync/previews/Breadcrumb.tsx
+++ b/.design-sync/previews/Breadcrumb.tsx
@@ -1,4 +1,4 @@
-import { Breadcrumb } from "new-site";
+import { Breadcrumb } from "maxharding4";
 
 export const TravelTrail = () => (
   <Breadcrumb

--- a/.design-sync/previews/CityCard.tsx
+++ b/.design-sync/previews/CityCard.tsx
@@ -1,4 +1,4 @@
-import { CityCard } from "new-site";
+import { CityCard } from "maxharding4";
 
 // CityCard takes a Contentful `Entry<CitySkeleton>` plus an optional preview
 // `Asset`. We mock the minimal shapes it reads (city.fields.name/slug and

--- a/.design-sync/previews/ContactInfo.tsx
+++ b/.design-sync/previews/ContactInfo.tsx
@@ -1,4 +1,4 @@
-import { ContactInfo } from "new-site";
+import { ContactInfo } from "maxharding4";
 
 export const FullContact = () => (
   <ContactInfo

--- a/.design-sync/previews/CountryCard.tsx
+++ b/.design-sync/previews/CountryCard.tsx
@@ -1,4 +1,4 @@
-import { CountryCard } from "new-site";
+import { CountryCard } from "maxharding4";
 
 // CountryCard takes a Contentful `Entry<CountrySkeleton>`. For previews we mock
 // the minimal shape it actually reads (name, slug, flagImage.fields.file.url)

--- a/.design-sync/previews/ExperienceCard.tsx
+++ b/.design-sync/previews/ExperienceCard.tsx
@@ -1,4 +1,4 @@
-import { ExperienceCard } from "new-site";
+import { ExperienceCard } from "maxharding4";
 
 export const CurrentRole = () => (
   <ExperienceCard

--- a/.design-sync/previews/NavigationCard.tsx
+++ b/.design-sync/previews/NavigationCard.tsx
@@ -1,4 +1,4 @@
-import { NavigationCard } from "new-site";
+import { NavigationCard } from "maxharding4";
 
 export const Travel = () => (
   <NavigationCard

--- a/.design-sync/previews/SkillsSection.tsx
+++ b/.design-sync/previews/SkillsSection.tsx
@@ -1,4 +1,4 @@
-import { SkillsSection } from "new-site";
+import { SkillsSection } from "maxharding4";
 
 export const MixedStack = () => (
   <SkillsSection

--- a/.design-sync/previews/Timeline.tsx
+++ b/.design-sync/previews/Timeline.tsx
@@ -1,4 +1,4 @@
-import { Timeline } from "new-site";
+import { Timeline } from "maxharding4";
 
 export const CareerTimeline = () => (
   <Timeline

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "new-site",
+  "name": "maxharding4",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "new-site",
+      "name": "maxharding4",
       "version": "0.1.0",
       "dependencies": {
         "contentful": "^11.10.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "new-site",
+  "name": "maxharding4",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
Aligns the project identity with the repo now that this is the live site.

## Changes
- `package.json` / `package-lock.json` name: `new-site` → `maxharding4`
- `.design-sync/config.json` `pkg` + the 9 `.design-sync/previews/*.tsx` imports updated to match (design-sync resolves previews via the package name, so they're coupled)
- Historical references in `tickets/` left as-is (they describe the migration)

## Tests
- lint, type-check, 790 tests all green
- App code doesn't import the package name (uses `@/` aliases), so no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)