### PR TITLE
Clarify manual-only deploy + add OAC hardening ticket

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,11 @@
 name: Build and deploy
 
-# Content is fetched from Contentful at build time, so a rebuild is how new
-# content goes live. Triggers:
-#   - push to main        -> deploy on code changes
-#   - workflow_dispatch   -> one-click "Run workflow" rebuild (e.g. after
-#                            publishing in Contentful), no commit required
-# Future option: add `repository_dispatch` + a Contentful publish webhook for
-# fully automatic rebuilds on content changes.
+# Manual-only by design: merges never auto-deploy. Publishing is always a
+# deliberate action — run this workflow with target=production to deploy. That
+# covers both code changes and picking up new content from Contentful (which is
+# fetched at build time). Optional future automation: repository_dispatch + a
+# Contentful publish webhook.
 on:
-  # Auto-deploy on push to main is enabled AFTER cutover (migration step 5).
-  # During migration the pipeline is manual-only, so nothing deploys until the
-  # "Run workflow" button is pressed deliberately.
   workflow_dispatch:
     inputs:
       target:
@@ -21,7 +16,7 @@ on:
           - staging      # -> s3://maxharding4.com/_staging/ (safe dry-run, no invalidation)
           - production   # -> s3://maxharding4.com/ (LIVE)
       prune:
-        description: "Delete bucket files not in this build (--delete). Leave OFF for the first production cutover."
+        description: "Delete bucket files not in this build (--delete). Leave OFF for normal deploys; turn ON to clean up orphaned files."
         type: boolean
         default: false
 

--- a/tickets/harden-cloudfront-oac.md
+++ b/tickets/harden-cloudfront-oac.md
@@ -1,0 +1,66 @@
+# Harden hosting: private S3 bucket + CloudFront Origin Access Control (OAC)
+
+**Type:** Task · **Status:** To Do · **Area:** Hosting / infra · **Priority:** Low
+
+## Objective
+
+Serve `maxharding4.com` from a **private** S3 bucket that only CloudFront can read,
+instead of the current public-bucket + S3-website-endpoint setup. This removes all
+public access to the bucket and makes CloudFront the only way to reach the content.
+
+## Current state (post-migration)
+
+- CloudFront origin is the **S3 static-website endpoint**.
+- The bucket `maxharding4.com` is **public-read** via a bucket policy
+  (`s3:GetObject` to `Principal: "*"`), which is what a website endpoint requires.
+- Anyone can therefore fetch objects directly from S3, bypassing CloudFront.
+
+This is a standard, secure-enough setup for a public static site — but not the
+gold standard. This ticket is the hardening step, not urgent.
+
+## Target state
+
+- Bucket is **fully private** (Block Public Access fully on, public bucket policy removed).
+- CloudFront reads the bucket via **Origin Access Control (OAC)**; a bucket policy
+  grants `s3:GetObject` only to the CloudFront distribution service principal
+  (scoped to distribution `E18D7W5LICE64E`).
+- CloudFront origin switched from the S3 **website** endpoint to the S3 **REST**
+  endpoint (`maxharding4.com.s3.eu-west-2.amazonaws.com`).
+
+## Technical Specifications
+
+1. **Create an OAC** (CloudFront → Origin access) and attach it to the distribution's
+   S3 origin; change the origin domain to the REST endpoint.
+2. **Bucket policy** → replace the public-read statement with an OAC-scoped one:
+   ```json
+   {
+     "Effect": "Allow",
+     "Principal": { "Service": "cloudfront.amazonaws.com" },
+     "Action": "s3:GetObject",
+     "Resource": "arn:aws:s3:::maxharding4.com/*",
+     "Condition": { "StringEquals": { "AWS:SourceArn": "arn:aws:cloudfront::091385753568:distribution/E18D7W5LICE64E" } }
+   }
+   ```
+3. **Re-enable Block Public Access** on the bucket once the policy is OAC-only.
+4. **Index/routing:** the REST endpoint does NOT do S3 website index-document
+   resolution, so `/travel/` → `travel/index.html` no longer happens automatically.
+   Add a **CloudFront Function** (viewer-request) to rewrite directory URLs to
+   `…/index.html`. This replaces the behaviour we currently get for free from the
+   website endpoint (we already ship folder-style routes via `trailingSlash`).
+5. Verify custom error handling (`404.html`) still works via CloudFront error responses.
+
+## Acceptance Criteria
+
+- [ ] Direct S3 object URLs return `AccessDenied`; the site is reachable only via CloudFront.
+- [ ] `maxharding4.com`, `/travel/`, city pages, `/cv/` all still return 200.
+- [ ] Block Public Access is fully enabled on the bucket.
+- [ ] Deploy pipeline (`aws s3 sync`) still works unchanged (it writes objects; OAC only affects reads).
+
+## Notes
+
+- **Risk:** this touches the live distribution's origin + routing. Do it behind a
+  test distribution or during a low-traffic window; keep the current public policy
+  ready to re-apply as instant rollback.
+- The **CloudFront Function for directory-index rewriting is the fiddly part** — it's
+  the piece the website endpoint currently handles for us. Budget most of the effort there.
+- No change needed to the GitHub Actions deploy (writes are unaffected by OAC).


### PR DESCRIPTION
## Summary
Post-migration docs cleanup — no functional change.

## Changes
- **`deploy.yml`**: replace the migration-era comments (which implied push-to-main auto-deploy would return) with the permanent design — deploys are **manual-only** via `workflow_dispatch`. Tidied the `prune` input description too.
- **`tickets/harden-cloudfront-oac.md`**: follow-up ticket to make the S3 bucket private (served only via CloudFront OAC) instead of the current public-read bucket policy. Low priority.

No code/tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)