### PR TITLE
Add cookbook section: recipe model tooling, /cookbook routes, v12 CMA migration

### DIFF
--- a/CONTENTFUL.md
+++ b/CONTENTFUL.md
@@ -68,6 +68,34 @@ California: US-CA
 | slug | Text | Yes | URL identifier |
 | visitDate | Date | No | Visit date |
 
+### Recipe (`recipe`)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| title | Text | Yes | Recipe name (display field) |
+| slug | Text | Yes | Unique, kebab-case; drives the static route |
+| category | Text | Yes | Dropdown, exactly: `mains`, `sides`, `snacks`, `desserts` |
+| description | Long text | No | Teaser shown on cards and the detail page |
+| image | Asset | No | Hero photo — landscape 3:2 (e.g. 1536×1024); cards render it uncropped |
+| ingredients | Long text | Yes | One ingredient per line |
+| method | Long text | Yes | One step per paragraph (blank-line separated) |
+| servings | Integer | No | |
+| prepTimeMinutes | Integer | No | Minutes |
+| cookTimeMinutes | Integer | No | Minutes |
+
+**Categories are not entries.** The four category values are fixed by a dropdown
+validation on `recipe`; the category pages (labels, blurbs, order) are defined in
+code at `src/lib/cookbook.ts`. A recipe with an unrecognised category value is
+skipped at build time with a warning.
+
+The content type was created programmatically — see
+`scripts/create-recipe-content-type.mjs` (idempotent, `--dry-run` supported).
+
+**Recipe photos:** keep originals in `photos/pre-processed/cookbook/<slug>.png`
+(gitignored, flat — no subfolders, or the processor's country/city renaming kicks
+in), run `scripts/process-photos-mixed.sh`, and attach the processed JPEG to the
+entry's `image` field.
+
 ### Photo (`photo`)
 
 | Field | Type | Required | Description |

--- a/scripts/create-locations.mjs
+++ b/scripts/create-locations.mjs
@@ -29,8 +29,7 @@
 //   CONTENTFUL_PHOTO_UPLOADER_TOKEN   Personal Access Token (CMA)
 //   CONTENTFUL_ENVIRONMENT            Optional, default "master"
 
-import contentfulManagement from "contentful-management";
-const { createClient } = contentfulManagement;
+import { createClient } from "contentful-management";
 import { existsSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
@@ -68,7 +67,7 @@ function titleFromSlug(slug) {
 // so the draft satisfies the required flagImage field and is publish-ready.
 // Returns true if a flag was attached (or would be, in dry-run), false if no
 // matching flag file exists (country is left flag-less with a warning).
-async function attachCountryFlag(env, countryEntry, countrySlug, locale, dryRun) {
+async function attachCountryFlag(cma, countryEntry, countrySlug, locale, dryRun) {
   const flagPath = join(FLAGS_DIR, `${countrySlug}.png`);
   if (!existsSync(flagPath)) {
     console.log(
@@ -80,27 +79,30 @@ async function attachCountryFlag(env, countryEntry, countrySlug, locale, dryRun)
     console.log(`   🏳️  [dry-run] would upload & attach flag ${countrySlug}.png`);
     return true;
   }
-  let asset = await env.createAssetFromFiles({
-    fields: {
-      title: { [locale]: `${titleFromSlug(countrySlug)} flag` },
-      file: {
-        [locale]: {
-          contentType: "image/png",
-          fileName: `${countrySlug}.png`,
-          file: await readFile(flagPath),
+  let asset = await cma.asset.createFromFiles(
+    {},
+    {
+      fields: {
+        title: { [locale]: `${titleFromSlug(countrySlug)} flag` },
+        file: {
+          [locale]: {
+            contentType: "image/png",
+            fileName: `${countrySlug}.png`,
+            file: await readFile(flagPath),
+          },
         },
       },
     },
-  });
-  asset = await asset.processForAllLocales();
-  asset = await asset.publish();
+  );
+  asset = await cma.asset.processForAllLocales({}, asset);
+  asset = await cma.asset.publish({ assetId: asset.sys.id }, asset);
 
   // Re-fetch the country for its latest version before linking the flag.
-  const fresh = await env.getEntry(countryEntry.sys.id);
+  const fresh = await cma.entry.get({ entryId: countryEntry.sys.id });
   fresh.fields.flagImage = {
     [locale]: { sys: { type: "Link", linkType: "Asset", id: asset.sys.id } },
   };
-  await fresh.update();
+  await cma.entry.update({ entryId: fresh.sys.id }, fresh);
   console.log(`   🏳️  attached flag ${countrySlug}.png → ${asset.sys.id}`);
   return true;
 }
@@ -119,12 +121,12 @@ function fieldValue(entry, fieldName, locale) {
   return f?.[locale] ?? f;
 }
 
-async function paginatedEntries(env, query) {
+async function paginatedEntries(cma, query) {
   const limit = 1000;
   const all = [];
   let skip = 0;
   while (true) {
-    const batch = await env.getEntries({ ...query, skip, limit });
+    const batch = await cma.entry.getMany({ query: { ...query, skip, limit } });
     all.push(...batch.items);
     if (batch.items.length < limit) break;
     skip += limit;
@@ -163,18 +165,25 @@ async function main() {
   console.log(`   Space:       ${CONTENTFUL_SPACE_ID}`);
   console.log(`   Environment: ${CONTENTFUL_ENVIRONMENT}`);
 
-  const client = createClient({ accessToken: CONTENTFUL_PHOTO_UPLOADER_TOKEN });
-  const space = await client.getSpace(CONTENTFUL_SPACE_ID);
-  const env = await space.getEnvironment(CONTENTFUL_ENVIRONMENT);
+  const cma = createClient(
+    { accessToken: CONTENTFUL_PHOTO_UPLOADER_TOKEN },
+    {
+      type: "plain",
+      defaults: {
+        spaceId: CONTENTFUL_SPACE_ID,
+        environmentId: CONTENTFUL_ENVIRONMENT,
+      },
+    },
+  );
 
-  const locales = await env.getLocales();
+  const locales = await cma.locale.getMany({});
   const locale = locales.items.find((l) => l.default)?.code ?? "en-US";
   console.log(`   Locale:      ${locale}\n`);
 
   console.log("📚 Indexing existing countries and cities...");
   const [existingCountries, existingCities] = await Promise.all([
-    paginatedEntries(env, { content_type: "country" }),
-    paginatedEntries(env, { content_type: "city" }),
+    paginatedEntries(cma, { content_type: "country" }),
+    paginatedEntries(cma, { content_type: "city" }),
   ]);
 
   const countryBySlug = new Map();
@@ -217,22 +226,25 @@ async function main() {
         );
         // Synthesise a placeholder so the city loop can still process subfolders.
         countryEntry = { sys: { id: `__dryrun__${countrySlug}` } };
-        await attachCountryFlag(env, countryEntry, countrySlug, locale, true);
+        await attachCountryFlag(cma, countryEntry, countrySlug, locale, true);
       } else {
         try {
-          countryEntry = await env.createEntry("country", {
-            fields: {
-              name: { [locale]: name },
-              slug: { [locale]: countrySlug },
+          countryEntry = await cma.entry.create(
+            { contentTypeId: "country" },
+            {
+              fields: {
+                name: { [locale]: name },
+                slug: { [locale]: countrySlug },
+              },
             },
-          });
+          );
           countryBySlug.set(countrySlug, countryEntry);
           countryById.set(countryEntry.sys.id, countryEntry);
           console.log(
             `🌍 ✅ Created Country: "${name}" (slug=${countrySlug}) → ${countryEntry.sys.id} (draft)`,
           );
           countriesCreated++;
-          await attachCountryFlag(env, countryEntry, countrySlug, locale, false);
+          await attachCountryFlag(cma, countryEntry, countrySlug, locale, false);
         } catch (e) {
           console.error(
             `🌍 ❌ Failed to create Country ${countrySlug}: ${e.message.split("\n")[0]}`,
@@ -262,21 +274,24 @@ async function main() {
         continue;
       }
       try {
-        const city = await env.createEntry("city", {
-          fields: {
-            name: { [locale]: name },
-            slug: { [locale]: citySlug },
-            country: {
-              [locale]: {
-                sys: {
-                  type: "Link",
-                  linkType: "Entry",
-                  id: countryEntry.sys.id,
+        const city = await cma.entry.create(
+          { contentTypeId: "city" },
+          {
+            fields: {
+              name: { [locale]: name },
+              slug: { [locale]: citySlug },
+              country: {
+                [locale]: {
+                  sys: {
+                    type: "Link",
+                    linkType: "Entry",
+                    id: countryEntry.sys.id,
+                  },
                 },
               },
             },
           },
-        });
+        );
         cityKeys.add(key);
         console.log(
           `   📍 ✅ Created City: "${name}" (slug=${citySlug}) → ${city.sys.id} (draft)`,

--- a/scripts/create-recipe-content-type.mjs
+++ b/scripts/create-recipe-content-type.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// Create the `recipe` content type in Contentful (see
+// tickets/cookbook-recipe-content-model.md for the model spec).
+//
+// Categories are a validated dropdown on the recipe itself — deliberately
+// NOT a separate content type. The four values (mains/sides/snacks/desserts)
+// are fixed; category pages are defined in code.
+//
+// Idempotent: if a `recipe` content type already exists the script reports
+// it and exits without touching it (no field merging/migration).
+//
+// Usage:
+//   node --env-file=.env.local scripts/create-recipe-content-type.mjs [--dry-run]
+//
+// Required env (typically in .env.local):
+//   CONTENTFUL_SPACE_ID
+//   CONTENTFUL_PHOTO_UPLOADER_TOKEN   Personal Access Token (CMA)
+//   CONTENTFUL_ENVIRONMENT            Optional, default "master"
+
+import { createClient } from "contentful-management";
+
+const CATEGORY_VALUES = ["mains", "sides", "snacks", "desserts"];
+const KEBAB_CASE = "^[a-z0-9]+(?:-[a-z0-9]+)*$";
+
+const RECIPE_CONTENT_TYPE = {
+  name: "Recipe",
+  description:
+    "A cookbook recipe. Category is a fixed dropdown (mains/sides/snacks/desserts); category pages are defined in code, not in Contentful.",
+  displayField: "title",
+  fields: [
+    { id: "title", name: "Title", type: "Symbol", required: true },
+    {
+      id: "slug",
+      name: "Slug",
+      type: "Symbol",
+      required: true,
+      validations: [
+        { unique: true },
+        {
+          regexp: { pattern: KEBAB_CASE },
+          message: "Use kebab-case, e.g. lemon-drizzle-cake",
+        },
+      ],
+    },
+    {
+      id: "category",
+      name: "Category",
+      type: "Symbol",
+      required: true,
+      validations: [{ in: CATEGORY_VALUES }],
+    },
+    { id: "description", name: "Description", type: "Text" },
+    {
+      id: "image",
+      name: "Image",
+      type: "Link",
+      linkType: "Asset",
+      validations: [{ linkMimetypeGroup: ["image"] }],
+    },
+    { id: "ingredients", name: "Ingredients", type: "Text", required: true },
+    { id: "method", name: "Method", type: "Text", required: true },
+    { id: "servings", name: "Servings", type: "Integer" },
+    { id: "prepTimeMinutes", name: "Prep time (minutes)", type: "Integer" },
+    { id: "cookTimeMinutes", name: "Cook time (minutes)", type: "Integer" },
+  ],
+};
+
+function die(msg) {
+  console.error(`❌ ${msg}`);
+  process.exit(1);
+}
+
+const dryRun = process.argv.includes("--dry-run");
+
+const {
+  CONTENTFUL_SPACE_ID,
+  CONTENTFUL_PHOTO_UPLOADER_TOKEN,
+  CONTENTFUL_ENVIRONMENT = "master",
+} = process.env;
+
+if (!CONTENTFUL_SPACE_ID) die("CONTENTFUL_SPACE_ID not set");
+if (!CONTENTFUL_PHOTO_UPLOADER_TOKEN) {
+  die(
+    "CONTENTFUL_PHOTO_UPLOADER_TOKEN not set. Create one at https://app.contentful.com/account/profile/cma_tokens",
+  );
+}
+
+const client = createClient(
+  { accessToken: CONTENTFUL_PHOTO_UPLOADER_TOKEN },
+  { type: "plain" },
+);
+const scope = {
+  spaceId: CONTENTFUL_SPACE_ID,
+  environmentId: CONTENTFUL_ENVIRONMENT,
+};
+
+let existing = null;
+try {
+  existing = await client.contentType.get({
+    ...scope,
+    contentTypeId: "recipe",
+  });
+} catch {
+  // 404 — doesn't exist yet, which is what we want
+}
+
+if (existing) {
+  console.log(
+    `✔ Content type "recipe" already exists (${existing.sys.publishedVersion ? "published" : "draft"}) — nothing to do.`,
+  );
+  process.exit(0);
+}
+
+if (dryRun) {
+  console.log("[dry-run] Would create + publish content type \"recipe\":");
+  for (const f of RECIPE_CONTENT_TYPE.fields) {
+    console.log(
+      `  - ${f.id} (${f.type}${f.linkType ? `<${f.linkType}>` : ""})${f.required ? " required" : ""}`,
+    );
+  }
+  process.exit(0);
+}
+
+const created = await client.contentType.createWithId(
+  { ...scope, contentTypeId: "recipe" },
+  RECIPE_CONTENT_TYPE,
+);
+await client.contentType.publish({ ...scope, contentTypeId: "recipe" }, created);
+console.log(
+  `✔ Created and published content type "recipe" in ${CONTENTFUL_SPACE_ID}/${CONTENTFUL_ENVIRONMENT} (${RECIPE_CONTENT_TYPE.fields.length} fields).`,
+);
+console.log(
+  "  Category dropdown values: " + CATEGORY_VALUES.join(", "),
+);

--- a/scripts/upload-to-contentful.mjs
+++ b/scripts/upload-to-contentful.mjs
@@ -31,8 +31,7 @@
 //   - Appends to `photos`; never replaces.
 //   - `--dry-run` prints actions without writing anything.
 
-import contentfulManagement from "contentful-management";
-const { createClient } = contentfulManagement;
+import { createClient } from "contentful-management";
 import { existsSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
 import { extname, join, resolve } from "node:path";
@@ -80,7 +79,7 @@ async function listImages(dir) {
     .sort();
 }
 
-async function ensureTag(env, id, name, cache, dryRun) {
+async function ensureTag(cma, id, name, cache, dryRun) {
   if (cache.has(id)) return;
   if (dryRun) {
     console.log(`   🏷️  [dry-run] would ensure tag: ${id}`);
@@ -88,12 +87,15 @@ async function ensureTag(env, id, name, cache, dryRun) {
     return;
   }
   try {
-    await env.createTag(id, name, "public");
+    await cma.tag.createWithId(
+      { tagId: id },
+      { name, sys: { visibility: "public" } },
+    );
     console.log(`   🏷️  created tag: ${id}`);
   } catch (err) {
     // Tag already exists is the common case on re-runs — verify by GET.
     try {
-      await env.getTag(id);
+      await cma.tag.get({ tagId: id });
     } catch {
       throw new Error(`Could not create or fetch tag "${id}": ${err.message}`);
     }
@@ -101,12 +103,12 @@ async function ensureTag(env, id, name, cache, dryRun) {
   cache.add(id);
 }
 
-async function paginatedEntries(env, query) {
+async function paginatedEntries(cma, query) {
   const limit = 1000;
   const all = [];
   let skip = 0;
   while (true) {
-    const batch = await env.getEntries({ ...query, skip, limit });
+    const batch = await cma.entry.getMany({ query: { ...query, skip, limit } });
     all.push(...batch.items);
     if (batch.items.length < limit) break;
     skip += limit;
@@ -127,10 +129,10 @@ function titleFromSlug(slug) {
     .join(" ");
 }
 
-async function buildCityIndex(env, locale) {
+async function buildCityIndex(cma, locale) {
   const [cities, countries] = await Promise.all([
-    paginatedEntries(env, { content_type: "city" }),
-    paginatedEntries(env, { content_type: "country" }),
+    paginatedEntries(cma, { content_type: "city" }),
+    paginatedEntries(cma, { content_type: "country" }),
   ]);
 
   const countryInfoById = new Map();
@@ -165,14 +167,16 @@ async function buildCityIndex(env, locale) {
   return index;
 }
 
-async function getCityPhotoFilenames(env, city, locale) {
+async function getCityPhotoFilenames(cma, city, locale) {
   const refs = city.fields?.photos?.[locale] ?? [];
   if (refs.length === 0) return new Set();
   const ids = refs.map((r) => r.sys.id);
   const filenames = new Set();
   for (let i = 0; i < ids.length; i += 100) {
     const chunk = ids.slice(i, i + 100);
-    const assets = await env.getAssets({ "sys.id[in]": chunk.join(",") });
+    const assets = await cma.asset.getMany({
+      query: { "sys.id[in]": chunk.join(",") },
+    });
     for (const a of assets.items) {
       const fn = a.fields?.file?.[locale]?.fileName;
       if (fn) filenames.add(fn);
@@ -182,7 +186,7 @@ async function getCityPhotoFilenames(env, city, locale) {
 }
 
 async function uploadOne(
-  env,
+  cma,
   filePath,
   fileName,
   countrySlug,
@@ -211,43 +215,48 @@ async function uploadOne(
   }
 
   const buffer = await readFile(filePath);
-  let asset = await env.createAssetFromFiles({
-    fields: {
-      title: { [locale]: title },
-      file: {
-        [locale]: {
-          contentType: contentTypeFor(fileName),
-          fileName,
-          file: buffer,
+  let asset = await cma.asset.createFromFiles(
+    {},
+    {
+      fields: {
+        title: { [locale]: title },
+        file: {
+          [locale]: {
+            contentType: contentTypeFor(fileName),
+            fileName,
+            file: buffer,
+          },
         },
       },
     },
-  });
+  );
 
   // Set tags before processing so they're attached on the first published version.
   asset.metadata = { tags: tagLinks };
-  asset = await asset.update();
+  asset = await cma.asset.update({ assetId: asset.sys.id }, asset);
 
-  asset = await asset.processForAllLocales();
-  asset = await asset.publish();
+  asset = await cma.asset.processForAllLocales({}, asset);
+  asset = await cma.asset.publish({ assetId: asset.sys.id }, asset);
   return asset;
 }
 
-async function resolvableAssetIds(env, ids) {
+async function resolvableAssetIds(cma, ids) {
   // Bulk-check which asset IDs still exist. Anything missing is a stale
   // link that will fail Contentful's "notResolvable" validation on write.
   const found = new Set();
   for (let i = 0; i < ids.length; i += 100) {
     const chunk = ids.slice(i, i + 100);
-    const assets = await env.getAssets({ "sys.id[in]": chunk.join(",") });
+    const assets = await cma.asset.getMany({
+      query: { "sys.id[in]": chunk.join(",") },
+    });
     for (const a of assets.items) found.add(a.sys.id);
   }
   return found;
 }
 
-async function appendPhotosToCity(env, cityId, newAssetIds, locale) {
+async function appendPhotosToCity(cma, cityId, newAssetIds, locale) {
   // Re-fetch to get the latest version before mutating.
-  const fresh = await env.getEntry(cityId);
+  const fresh = await cma.entry.get({ entryId: cityId });
   const existing = fresh.fields?.photos?.[locale] ?? [];
 
   // Filter out unresolvable links — Contentful rejects updates that
@@ -255,7 +264,7 @@ async function appendPhotosToCity(env, cityId, newAssetIds, locale) {
   let cleanExisting = existing;
   if (existing.length > 0) {
     const resolvable = await resolvableAssetIds(
-      env,
+      cma,
       existing.map((l) => l.sys.id),
     );
     cleanExisting = existing.filter((l) => resolvable.has(l.sys.id));
@@ -268,11 +277,11 @@ async function appendPhotosToCity(env, cityId, newAssetIds, locale) {
     ...(fresh.fields.photos ?? {}),
     [locale]: [...cleanExisting, ...links],
   };
-  const updated = await fresh.update();
-  await updated.publish();
+  const updated = await cma.entry.update({ entryId: cityId }, fresh);
+  await cma.entry.publish({ entryId: cityId }, updated);
 }
 
-async function relinkCity(env, cityInfo, citySlug, locale, dryRun) {
+async function relinkCity(cma, cityInfo, citySlug, locale, dryRun) {
   // Find every published asset tagged with city-<slug>, sort by fileName
   // (which equals the upload order thanks to our naming scheme), and
   // overwrite the city's photos array. Replacing — not appending — so
@@ -282,10 +291,8 @@ async function relinkCity(env, cityInfo, citySlug, locale, dryRun) {
   let skip = 0;
   const limit = 1000;
   while (true) {
-    const batch = await env.getAssets({
-      "metadata.tags.sys.id[in]": tagId,
-      skip,
-      limit,
+    const batch = await cma.asset.getMany({
+      query: { "metadata.tags.sys.id[in]": tagId, skip, limit },
     });
     allTagged.push(...batch.items);
     if (batch.items.length < limit) break;
@@ -309,7 +316,7 @@ async function relinkCity(env, cityInfo, citySlug, locale, dryRun) {
     return { linked: validAssets.length, dryRun: true, validAssets };
   }
 
-  const fresh = await env.getEntry(cityInfo.entry.sys.id);
+  const fresh = await cma.entry.get({ entryId: cityInfo.entry.sys.id });
   const links = validAssets.map((a) => ({
     sys: { type: "Link", linkType: "Asset", id: a.sys.id },
   }));
@@ -317,8 +324,8 @@ async function relinkCity(env, cityInfo, citySlug, locale, dryRun) {
     ...(fresh.fields.photos ?? {}),
     [locale]: links,
   };
-  const updated = await fresh.update();
-  await updated.publish();
+  const updated = await cma.entry.update({ entryId: fresh.sys.id }, fresh);
+  await cma.entry.publish({ entryId: fresh.sys.id }, updated);
   return { linked: validAssets.length };
 }
 
@@ -327,7 +334,7 @@ async function relinkCity(env, cityInfo, citySlug, locale, dryRun) {
 // "photo.jpg") are never picked up.
 const NAMING_PATTERN = /^[a-z]+(-[a-z]+)+-\d{3}\.jpg$/;
 
-async function cleanupDrafts(env, locale, dryRun) {
+async function cleanupDrafts(cma, locale, dryRun) {
   console.log(
     "🧹 Scanning for unpublished draft assets matching <country>-<city>-NNN.jpg...",
   );
@@ -336,7 +343,7 @@ async function cleanupDrafts(env, locale, dryRun) {
   let skip = 0;
   const limit = 1000;
   while (true) {
-    const batch = await env.getAssets({ skip, limit });
+    const batch = await cma.asset.getMany({ query: { skip, limit } });
     for (const a of batch.items) {
       if (a.sys.publishedVersion) continue; // Skip anything already published.
       const fileEntry = a.fields?.file?.[locale];
@@ -366,7 +373,7 @@ async function cleanupDrafts(env, locale, dryRun) {
     const { asset, fileName } = drafts[i];
     const progress = `[${i + 1}/${drafts.length}]`;
     try {
-      await asset.delete();
+      await cma.asset.delete({ assetId: asset.sys.id });
       console.log(`   ${progress} 🗑️  ${fileName}`);
       deleted++;
     } catch (e) {
@@ -425,16 +432,23 @@ async function main() {
   console.log(`   Space:       ${CONTENTFUL_SPACE_ID}`);
   console.log(`   Environment: ${CONTENTFUL_ENVIRONMENT}`);
 
-  const client = createClient({ accessToken: CONTENTFUL_PHOTO_UPLOADER_TOKEN });
-  const space = await client.getSpace(CONTENTFUL_SPACE_ID);
-  const env = await space.getEnvironment(CONTENTFUL_ENVIRONMENT);
+  const cma = createClient(
+    { accessToken: CONTENTFUL_PHOTO_UPLOADER_TOKEN },
+    {
+      type: "plain",
+      defaults: {
+        spaceId: CONTENTFUL_SPACE_ID,
+        environmentId: CONTENTFUL_ENVIRONMENT,
+      },
+    },
+  );
 
-  const locales = await env.getLocales();
+  const locales = await cma.locale.getMany({});
   const locale = locales.items.find((l) => l.default)?.code ?? "en-US";
   console.log(`   Locale:      ${locale}\n`);
 
   if (cleanupMode) {
-    const { deleted, errors } = await cleanupDrafts(env, locale, dryRun);
+    const { deleted, errors } = await cleanupDrafts(cma, locale, dryRun);
     console.log("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     console.log(`Cleanup done.${dryRun ? " (dry run, no writes)" : ""}`);
     console.log(`Deleted: ${deleted}`);
@@ -443,7 +457,7 @@ async function main() {
   }
 
   console.log("📚 Indexing existing countries and cities...");
-  const cityIndex = await buildCityIndex(env, locale);
+  const cityIndex = await buildCityIndex(cma, locale);
   console.log(`   ${cityIndex.size} city entr${cityIndex.size === 1 ? "y" : "ies"} mapped.\n`);
 
   if (relinkMode) {
@@ -463,7 +477,7 @@ async function main() {
           continue;
         }
         try {
-          const result = await relinkCity(env, cityInfo, citySlug, locale, dryRun);
+          const result = await relinkCity(cma, cityInfo, citySlug, locale, dryRun);
           if (result.skipped) {
             console.log(
               `📍 ${key} — ⚠️  no published assets tagged city-${citySlug}, skipping (refusing to clear existing photos)`,
@@ -503,7 +517,7 @@ async function main() {
     const countryPath = join(absInput, countrySlug);
     const citySlugs = await listSubdirs(countryPath);
     try {
-      await ensureTag(env, `country-${countrySlug}`, countrySlug, tagCache, dryRun);
+      await ensureTag(cma, `country-${countrySlug}`, countrySlug, tagCache, dryRun);
     } catch (e) {
       console.error(`⚠️  ${countrySlug}: ${e.message}`);
     }
@@ -523,14 +537,14 @@ async function main() {
       const { entry: cityEntry, cityName, countryName } = cityInfo;
 
       try {
-        await ensureTag(env, `city-${citySlug}`, citySlug, tagCache, dryRun);
+        await ensureTag(cma, `city-${citySlug}`, citySlug, tagCache, dryRun);
       } catch (e) {
         console.error(`   ⚠️  ${e.message}`);
       }
 
       const existing = dryRun
         ? new Set()
-        : await getCityPhotoFilenames(env, cityEntry, locale);
+        : await getCityPhotoFilenames(cma, cityEntry, locale);
 
       const newAssetIds = [];
       for (let i = 0; i < files.length; i++) {
@@ -544,7 +558,7 @@ async function main() {
         }
         try {
           const asset = await uploadOne(
-            env,
+            cma,
             filePath,
             fileName,
             countrySlug,
@@ -567,7 +581,7 @@ async function main() {
 
       if (newAssetIds.length > 0 && !dryRun) {
         try {
-          await appendPhotosToCity(env, cityEntry.sys.id, newAssetIds, locale);
+          await appendPhotosToCity(cma, cityEntry.sys.id, newAssetIds, locale);
           console.log(
             `   📎 Linked ${newAssetIds.length} asset(s) to city entry & republished.\n`,
           );

--- a/src/app/__tests__/cookbook-category-page.test.tsx
+++ b/src/app/__tests__/cookbook-category-page.test.tsx
@@ -1,0 +1,125 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen } from "@testing-library/react";
+import CategoryPage, { generateStaticParams } from "../cookbook/[categorySlug]/page";
+import * as contentful from "@/lib/contentful";
+import { notFound } from "next/navigation";
+import { Entry, EntryCollection } from "contentful";
+import { RecipeSkeleton } from "@/types/contentful";
+import React from "react";
+
+// Mock Next.js Image component
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props;
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...rest} data-fill={fill ? "true" : "false"} />;
+  },
+}));
+
+// Mock Next.js Link component
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    className,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+jest.mock("@/lib/contentful");
+
+const mockGetEntriesByType = contentful.getEntriesByType as jest.MockedFunction<
+  typeof contentful.getEntriesByType
+>;
+
+function mockRecipe(slug: string, category: string): Entry<RecipeSkeleton> {
+  return {
+    sys: { id: `id-${slug}` },
+    fields: {
+      title: slug,
+      slug,
+      category,
+      ingredients: "a",
+      method: "b",
+    },
+  } as unknown as Entry<RecipeSkeleton>;
+}
+
+function asCollection(items: Entry<RecipeSkeleton>[]) {
+  return {
+    items,
+    total: items.length,
+    skip: 0,
+    limit: 100,
+    sys: { type: "Array" },
+  } as unknown as EntryCollection<RecipeSkeleton>;
+}
+
+function pageParams(categorySlug: string) {
+  return { params: Promise.resolve({ categorySlug }) };
+}
+
+describe("CategoryPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("generates static params for exactly the four configured categories", async () => {
+    expect(await generateStaticParams()).toEqual([
+      { categorySlug: "mains" },
+      { categorySlug: "sides" },
+      { categorySlug: "snacks" },
+      { categorySlug: "desserts" },
+    ]);
+  });
+
+  it("renders only the recipes in the requested category", async () => {
+    mockGetEntriesByType.mockResolvedValue(
+      asCollection([
+        mockRecipe("lasagne", "mains"),
+        mockRecipe("flapjack", "snacks"),
+      ])
+    );
+
+    render(await CategoryPage(pageParams("mains")));
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Mains");
+    expect(screen.getByText("lasagne")).toBeInTheDocument();
+    expect(screen.queryByText("flapjack")).not.toBeInTheDocument();
+    expect(screen.getByText("1 recipe")).toBeInTheDocument();
+  });
+
+  it("shows the empty state for a category with no recipes", async () => {
+    mockGetEntriesByType.mockResolvedValue(asCollection([]));
+
+    render(await CategoryPage(pageParams("desserts")));
+
+    expect(screen.getByText("Recipes coming soon")).toBeInTheDocument();
+    expect(screen.getByText("0 recipes")).toBeInTheDocument();
+  });
+
+  it("404s for an unknown category slug", async () => {
+    mockGetEntriesByType.mockResolvedValue(asCollection([]));
+
+    await expect(CategoryPage(pageParams("starters"))).rejects.toThrow(
+      "NEXT_NOT_FOUND"
+    );
+    expect(notFound).toHaveBeenCalled();
+  });
+});

--- a/src/app/__tests__/cookbook-page.test.tsx
+++ b/src/app/__tests__/cookbook-page.test.tsx
@@ -1,0 +1,132 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen } from "@testing-library/react";
+import CookbookPage from "../cookbook/page";
+import * as contentful from "@/lib/contentful";
+import { Entry, EntryCollection } from "contentful";
+import { RecipeSkeleton } from "@/types/contentful";
+import React from "react";
+
+// Mock Next.js Image component
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props;
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...rest} data-fill={fill ? "true" : "false"} />;
+  },
+}));
+
+// Mock Next.js Link component
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    className,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("@/lib/contentful");
+
+const mockGetEntriesByType = contentful.getEntriesByType as jest.MockedFunction<
+  typeof contentful.getEntriesByType
+>;
+
+function mockRecipe(slug: string, category: string): Entry<RecipeSkeleton> {
+  return {
+    sys: { id: `id-${slug}` },
+    fields: {
+      title: slug,
+      slug,
+      category,
+      image: { fields: { file: { url: `//images.ctfassets.net/x/${slug}.jpg` } } },
+      ingredients: "a",
+      method: "b",
+    },
+  } as unknown as Entry<RecipeSkeleton>;
+}
+
+function asCollection(items: Entry<RecipeSkeleton>[]) {
+  return {
+    items,
+    total: items.length,
+    skip: 0,
+    limit: 100,
+    sys: { type: "Array" },
+  } as unknown as EntryCollection<RecipeSkeleton>;
+}
+
+describe("CookbookPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders all four category cards in order", async () => {
+    mockGetEntriesByType.mockResolvedValue(asCollection([]));
+
+    render(await CookbookPage());
+
+    const headings = screen.getAllByRole("heading", { level: 2 });
+    expect(headings.map((h) => h.textContent)).toEqual([
+      "Mains",
+      "Sides",
+      "Snacks",
+      "Desserts",
+    ]);
+  });
+
+  it("links populated categories and shows their recipe count", async () => {
+    mockGetEntriesByType.mockResolvedValue(
+      asCollection([
+        mockRecipe("lasagne", "mains"),
+        mockRecipe("carbonara", "mains"),
+      ])
+    );
+
+    render(await CookbookPage());
+
+    expect(screen.getByRole("link", { name: /Mains/ })).toHaveAttribute(
+      "href",
+      "/cookbook/mains"
+    );
+    expect(screen.getByText("2 recipes")).toBeInTheDocument();
+  });
+
+  it("renders empty categories as non-clickable coming-soon cards", async () => {
+    mockGetEntriesByType.mockResolvedValue(
+      asCollection([mockRecipe("lasagne", "mains")])
+    );
+
+    render(await CookbookPage());
+
+    // Mains is a link; the three empty categories are not.
+    expect(screen.getAllByRole("link")).toHaveLength(1);
+    expect(screen.getAllByRole("status")).toHaveLength(3);
+    expect(
+      screen.getByLabelText(/Desserts - Coming soon/)
+    ).toBeInTheDocument();
+  });
+
+  it("uses the first recipe's photo as the category preview image", async () => {
+    mockGetEntriesByType.mockResolvedValue(
+      asCollection([mockRecipe("lasagne", "mains")])
+    );
+
+    render(await CookbookPage());
+
+    const img = screen.getByRole("img", { name: "Mains recipes" });
+    expect(img).toHaveAttribute(
+      "src",
+      expect.stringContaining("lasagne.jpg")
+    );
+  });
+});

--- a/src/app/__tests__/cookbook-recipe-page.test.tsx
+++ b/src/app/__tests__/cookbook-recipe-page.test.tsx
@@ -1,0 +1,155 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen } from "@testing-library/react";
+import RecipePage from "../cookbook/[categorySlug]/[recipeSlug]/page";
+import * as contentful from "@/lib/contentful";
+import { notFound } from "next/navigation";
+import { Entry, EntryCollection } from "contentful";
+import { RecipeSkeleton } from "@/types/contentful";
+import React from "react";
+
+// Mock Next.js Image component
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { fill, priority, ...rest } = props;
+    return (
+      // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+      <img
+        {...rest}
+        data-fill={fill ? "true" : "false"}
+        data-priority={priority ? "true" : "false"}
+      />
+    );
+  },
+}));
+
+// Mock Next.js Link component
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    className,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+jest.mock("@/lib/contentful");
+
+const mockGetEntriesByType = contentful.getEntriesByType as jest.MockedFunction<
+  typeof contentful.getEntriesByType
+>;
+
+const RECIPE = {
+  sys: { id: "recipe-1" },
+  fields: {
+    title: "Spaghetti Bolognese",
+    slug: "spaghetti-bolognese",
+    category: "mains",
+    description: "Healthy weeknight version.",
+    image: {
+      fields: { file: { url: "//images.ctfassets.net/x/bolognese.jpg" } },
+    },
+    ingredients: "500g lean beef mince\n1 onion, coarsely grated",
+    method: "Brown the mince.\n\nSimmer the sauce.",
+    servings: 4,
+  },
+} as unknown as Entry<RecipeSkeleton>;
+
+function asCollection(items: Entry<RecipeSkeleton>[]) {
+  return {
+    items,
+    total: items.length,
+    skip: 0,
+    limit: 100,
+    sys: { type: "Array" },
+  } as unknown as EntryCollection<RecipeSkeleton>;
+}
+
+function pageParams(categorySlug: string, recipeSlug: string) {
+  return { params: Promise.resolve({ categorySlug, recipeSlug }) };
+}
+
+describe("RecipePage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders title, meta, ingredients list and numbered method steps", async () => {
+    mockGetEntriesByType.mockResolvedValue(asCollection([RECIPE]));
+
+    render(await RecipePage(pageParams("mains", "spaghetti-bolognese")));
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Spaghetti Bolognese"
+    );
+    expect(screen.getByText("Serves 4")).toBeInTheDocument();
+
+    const ingredients = screen.getByRole("heading", { name: "Ingredients" });
+    expect(ingredients).toBeInTheDocument();
+    expect(screen.getByText("500g lean beef mince")).toBeInTheDocument();
+    expect(screen.getByText("1 onion, coarsely grated")).toBeInTheDocument();
+
+    expect(screen.getByRole("heading", { name: "Method" })).toBeInTheDocument();
+    expect(screen.getByText("Brown the mince.")).toBeInTheDocument();
+    expect(screen.getByText("Simmer the sauce.")).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("img", { name: "Photo of Spaghetti Bolognese" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders breadcrumbs back to the category and cookbook", async () => {
+    mockGetEntriesByType.mockResolvedValue(asCollection([RECIPE]));
+
+    render(await RecipePage(pageParams("mains", "spaghetti-bolognese")));
+
+    expect(screen.getByRole("link", { name: "Cookbook" })).toHaveAttribute(
+      "href",
+      "/cookbook"
+    );
+    expect(screen.getByRole("link", { name: "Mains" })).toHaveAttribute(
+      "href",
+      "/cookbook/mains"
+    );
+  });
+
+  it("404s for an unknown recipe slug", async () => {
+    mockGetEntriesByType.mockResolvedValue(asCollection([]));
+
+    await expect(
+      RecipePage(pageParams("mains", "not-a-recipe"))
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it("404s for an unknown category slug", async () => {
+    mockGetEntriesByType.mockResolvedValue(asCollection([RECIPE]));
+
+    await expect(
+      RecipePage(pageParams("starters", "spaghetti-bolognese"))
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+  });
+
+  it("404s when the recipe exists but under a different category", async () => {
+    mockGetEntriesByType.mockResolvedValue(asCollection([RECIPE]));
+
+    await expect(
+      RecipePage(pageParams("desserts", "spaghetti-bolognese"))
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+  });
+});

--- a/src/app/cookbook/[categorySlug]/[recipeSlug]/page.tsx
+++ b/src/app/cookbook/[categorySlug]/[recipeSlug]/page.tsx
@@ -1,0 +1,202 @@
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { Asset } from "contentful";
+import Breadcrumb from "@/components/Breadcrumb";
+import { getEntriesByType } from "@/lib/contentful";
+import { getCategory, getAllRecipes, splitIngredients, splitMethodSteps } from "@/lib/cookbook";
+import { getContentfulImageSrc, IMAGE_TRANSFORMS } from "@/lib/images";
+import { RecipeSkeleton } from "@/types/contentful";
+
+interface RecipePageProps {
+  params: Promise<{
+    categorySlug: string;
+    recipeSlug: string;
+  }>;
+}
+
+export async function generateStaticParams() {
+  const recipes = await getAllRecipes();
+
+  return recipes.map((recipe) => ({
+    categorySlug: recipe.fields.category as unknown as string,
+    recipeSlug: recipe.fields.slug as unknown as string,
+  }));
+}
+
+export async function generateMetadata({ params }: RecipePageProps) {
+  const { categorySlug, recipeSlug } = await params;
+
+  const recipes = await getEntriesByType<RecipeSkeleton>("recipe", {
+    "fields.slug": recipeSlug,
+    limit: 1,
+  });
+  const recipe = recipes.items[0];
+  const category = getCategory(categorySlug);
+
+  if (!recipe || !category) {
+    return { title: "Recipe Not Found" };
+  }
+
+  const title = recipe.fields.title as unknown as string;
+  const description = recipe.fields.description as unknown as string | undefined;
+  const image = recipe.fields.image as unknown as Asset | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const imageUrl = (image?.fields as any)?.file?.url as string | undefined;
+
+  const metaDescription = description || `${title} — a ${category.label.toLowerCase()} recipe from my cookbook.`;
+
+  return {
+    title: `${title} | Cookbook`,
+    description: metaDescription,
+    openGraph: {
+      title: `${title} | Cookbook`,
+      description: metaDescription,
+      url: `/cookbook/${categorySlug}/${recipeSlug}`,
+      type: "article",
+      ...(imageUrl && {
+        images: [{ url: `https:${imageUrl}`, alt: `Photo of ${title}` }],
+      }),
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${title} | Cookbook`,
+      description: metaDescription,
+      ...(imageUrl && { images: [`https:${imageUrl}`] }),
+    },
+  };
+}
+
+export default async function RecipePage({ params }: RecipePageProps) {
+  const { categorySlug, recipeSlug } = await params;
+
+  const category = getCategory(categorySlug);
+  if (!category) {
+    notFound();
+  }
+
+  const recipes = await getEntriesByType<RecipeSkeleton>("recipe", {
+    "fields.slug": recipeSlug,
+    limit: 1,
+  });
+  const recipe = recipes.items[0];
+
+  if (!recipe) {
+    notFound();
+  }
+
+  // A recipe only lives under its own category's URL.
+  if ((recipe.fields.category as unknown as string) !== category.slug) {
+    notFound();
+  }
+
+  const title = recipe.fields.title as unknown as string;
+  const description = recipe.fields.description as unknown as string | undefined;
+  const image = recipe.fields.image as unknown as Asset | undefined;
+  const servings = recipe.fields.servings as unknown as number | undefined;
+  const prep = recipe.fields.prepTimeMinutes as unknown as number | undefined;
+  const cook = recipe.fields.cookTimeMinutes as unknown as number | undefined;
+  const ingredients = splitIngredients(recipe.fields.ingredients as unknown as string);
+  const steps = splitMethodSteps(recipe.fields.method as unknown as string);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const imageUrl = (image?.fields as any)?.file?.url as string | undefined;
+
+  const breadcrumbItems = [
+    { label: "Cookbook", href: "/cookbook" },
+    { label: category.label, href: `/cookbook/${category.slug}` },
+    { label: title },
+  ];
+
+  const recipeSchema = {
+    "@context": "https://schema.org",
+    "@type": "Recipe",
+    name: title,
+    ...(description && { description }),
+    ...(imageUrl && { image: `https:${imageUrl}` }),
+    ...(servings && { recipeYield: servings }),
+    ...(prep && { prepTime: `PT${prep}M` }),
+    ...(cook && { cookTime: `PT${cook}M` }),
+    recipeCategory: category.label,
+    recipeIngredient: ingredients,
+    recipeInstructions: steps.map((text, i) => ({
+      "@type": "HowToStep",
+      name: `Step ${i + 1}`,
+      text,
+    })),
+  };
+
+  const metaParts = [
+    servings && `Serves ${servings}`,
+    prep && `Prep ${prep} min`,
+    cook && `Cook ${cook} min`,
+  ].filter(Boolean) as string[];
+
+  return (
+    <div className="min-h-screen page-canvas">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(recipeSchema) }}
+      />
+      <div className="container mx-auto px-4 py-12 sm:px-6 lg:px-8">
+        <Breadcrumb items={breadcrumbItems} />
+
+        {/* Constrained reading column: recipe photos are 1536px wide, which is
+            exactly 2× retina-sharp at max-w-3xl. Not full-bleed by design. */}
+        <article className="mx-auto max-w-3xl">
+          <header className="mb-8">
+            <h1 className="heading-hero text-gray-900">{title}</h1>
+            {description && (
+              <p className="mt-4 text-lg text-gray-600">{description}</p>
+            )}
+            {metaParts.length > 0 && (
+              <p className="mt-3 text-sm font-medium text-gray-500">
+                {metaParts.join(" · ")}
+              </p>
+            )}
+          </header>
+
+          {imageUrl && (
+            <div className="relative mb-10 aspect-[3/2] w-full overflow-hidden rounded-lg bg-gray-100">
+              <Image
+                src={getContentfulImageSrc(imageUrl, IMAGE_TRANSFORMS.recipeHero)}
+                alt={`Photo of ${title}`}
+                fill
+                sizes="(max-width: 768px) 100vw, 768px"
+                className="object-cover"
+                priority
+              />
+            </div>
+          )}
+
+          <section aria-labelledby="ingredients-heading" className="mb-10">
+            <h2
+              id="ingredients-heading"
+              className="text-2xl font-semibold text-gray-900 mb-4"
+            >
+              Ingredients
+            </h2>
+            <ul className="list-disc space-y-2 pl-5 text-gray-700">
+              {ingredients.map((ingredient) => (
+                <li key={ingredient}>{ingredient}</li>
+              ))}
+            </ul>
+          </section>
+
+          <section aria-labelledby="method-heading">
+            <h2
+              id="method-heading"
+              className="text-2xl font-semibold text-gray-900 mb-4"
+            >
+              Method
+            </h2>
+            <ol className="list-decimal space-y-4 pl-5 text-gray-700">
+              {steps.map((step) => (
+                <li key={step}>{step}</li>
+              ))}
+            </ol>
+          </section>
+        </article>
+      </div>
+    </div>
+  );
+}

--- a/src/app/cookbook/[categorySlug]/page.tsx
+++ b/src/app/cookbook/[categorySlug]/page.tsx
@@ -1,0 +1,91 @@
+import { notFound } from "next/navigation";
+import Breadcrumb from "@/components/Breadcrumb";
+import RecipeCard from "@/components/RecipeCard";
+import { CATEGORIES, getAllRecipes, getCategory, recipesInCategory } from "@/lib/cookbook";
+
+interface CategoryPageProps {
+  params: Promise<{
+    categorySlug: string;
+  }>;
+}
+
+// All four category pages are generated even when empty — the empty state
+// below renders instead of a bare grid.
+export async function generateStaticParams() {
+  return CATEGORIES.map((category) => ({ categorySlug: category.slug }));
+}
+
+export async function generateMetadata({ params }: CategoryPageProps) {
+  const { categorySlug } = await params;
+  const category = getCategory(categorySlug);
+
+  if (!category) {
+    return { title: "Category Not Found" };
+  }
+
+  const description = `${category.label} recipes from my cookbook. ${category.blurb}`;
+
+  return {
+    title: `${category.label} | Cookbook`,
+    description,
+    openGraph: {
+      title: `${category.label} | Cookbook`,
+      description,
+      url: `/cookbook/${category.slug}`,
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${category.label} | Cookbook`,
+      description,
+    },
+  };
+}
+
+export default async function CategoryPage({ params }: CategoryPageProps) {
+  const { categorySlug } = await params;
+  const category = getCategory(categorySlug);
+
+  if (!category) {
+    notFound();
+  }
+
+  const recipes = recipesInCategory(await getAllRecipes(), category.slug);
+
+  const breadcrumbItems = [
+    { label: "Cookbook", href: "/cookbook" },
+    { label: category.label },
+  ];
+
+  return (
+    <div className="min-h-screen page-canvas">
+      <div className="container mx-auto px-4 py-12 sm:px-6 lg:px-8">
+        <Breadcrumb items={breadcrumbItems} />
+
+        <header className="mb-12">
+          <h1 className="heading-hero text-gray-900">{category.label}</h1>
+          <p className="mt-4 text-lg text-gray-600 max-w-2xl">{category.blurb}</p>
+          <p className="mt-2 text-sm text-gray-500">
+            {recipes.length} {recipes.length === 1 ? "recipe" : "recipes"}
+          </p>
+        </header>
+
+        {recipes.length > 0 ? (
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {recipes.map((recipe) => (
+              <RecipeCard
+                key={recipe.sys.id}
+                recipe={recipe}
+                categorySlug={category.slug}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-12">
+            <p className="text-gray-500 text-lg">Recipes coming soon</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/cookbook/page.tsx
+++ b/src/app/cookbook/page.tsx
@@ -1,0 +1,71 @@
+import { Asset } from "contentful";
+import CategoryCard from "@/components/CategoryCard";
+import { CATEGORIES, getAllRecipes, recipesInCategory } from "@/lib/cookbook";
+
+// Note: content is fetched at build time only (output: 'export').
+// Run 'npm run build' to pick up new recipes.
+
+export default async function CookbookPage() {
+  const recipes = await getAllRecipes();
+
+  const categoriesWithRecipes = CATEGORIES.map((category) => {
+    const categoryRecipes = recipesInCategory(recipes, category.slug);
+    const firstImage = categoryRecipes
+      .map((r) => r.fields.image as unknown as Asset | undefined)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .map((image) => (image?.fields as any)?.file?.url as string | undefined)
+      .find(Boolean);
+    return {
+      category,
+      recipeCount: categoryRecipes.length,
+      previewImageUrl: firstImage ?? null,
+    };
+  });
+
+  return (
+    <div className="min-h-screen page-canvas">
+      <div className="container mx-auto px-4 py-12 sm:px-6 lg:px-8">
+        <header className="mb-12">
+          <h1 className="heading-hero text-gray-900">Cookbook</h1>
+          <p className="mt-4 text-lg text-gray-600 max-w-2xl">
+            Recipes I actually cook — mains, sides, snacks and desserts.
+          </p>
+        </header>
+
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {categoriesWithRecipes.map(({ category, recipeCount, previewImageUrl }) => (
+            <CategoryCard
+              key={category.slug}
+              category={category}
+              recipeCount={recipeCount}
+              previewImageUrl={previewImageUrl}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export async function generateMetadata() {
+  const recipes = await getAllRecipes();
+  const description = `A personal cookbook of ${recipes.length} ${
+    recipes.length === 1 ? "recipe" : "recipes"
+  } across mains, sides, snacks and desserts.`;
+
+  return {
+    title: "Cookbook | Recipes I Actually Cook",
+    description,
+    openGraph: {
+      title: "Cookbook | Recipes I Actually Cook",
+      description,
+      url: "/cookbook",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: "Cookbook | Recipes I Actually Cook",
+      description,
+    },
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { MetadataRoute } from "next";
 import { getEntriesByType } from "@/lib/contentful";
+import { CATEGORIES, getAllRecipes } from "@/lib/cookbook";
 import { CountrySkeleton, CitySkeleton } from "@/types/contentful";
 import { Entry } from "contentful";
 
@@ -13,10 +14,11 @@ export const dynamic = "force-static";
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = "https://maxharding4.com";
 
-  // Fetch all countries and cities from Contentful
-  const [countriesResponse, citiesResponse] = await Promise.all([
+  // Fetch all countries, cities and recipes from Contentful
+  const [countriesResponse, citiesResponse, recipes] = await Promise.all([
     getEntriesByType<CountrySkeleton>("country"),
     getEntriesByType<CitySkeleton>("city"),
+    getAllRecipes(),
   ]);
 
   const countries = countriesResponse.items;
@@ -42,7 +44,31 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "daily",
       priority: 0.6,
     },
+    {
+      url: `${baseUrl}/cookbook`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
   ];
+
+  // Cookbook category pages (code-defined, always present)
+  const categoryPages: MetadataRoute.Sitemap = CATEGORIES.map((category) => ({
+    url: `${baseUrl}/cookbook/${category.slug}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: 0.7,
+  }));
+
+  // Recipe pages
+  const recipePages: MetadataRoute.Sitemap = recipes.map((recipe) => ({
+    url: `${baseUrl}/cookbook/${recipe.fields.category as unknown as string}/${
+      recipe.fields.slug as unknown as string
+    }`,
+    lastModified: new Date(recipe.sys.updatedAt),
+    changeFrequency: "monthly" as const,
+    priority: 0.6,
+  }));
 
   // Dynamic country pages
   const countryPages: MetadataRoute.Sitemap = countries.map((country) => ({
@@ -70,5 +96,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       };
     });
 
-  return [...staticPages, ...countryPages, ...cityPages];
+  return [...staticPages, ...countryPages, ...cityPages, ...categoryPages, ...recipePages];
 }

--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -1,0 +1,106 @@
+import Image from "next/image";
+import Link from "next/link";
+import { CategoryConfig } from "@/lib/cookbook";
+import { getContentfulImageSrc, IMAGE_TRANSFORMS } from "@/lib/images";
+
+interface CategoryCardProps {
+  category: CategoryConfig;
+  recipeCount: number;
+  /** Contentful asset URL of the category's preview image (first recipe's photo) */
+  previewImageUrl?: string | null;
+}
+
+export default function CategoryCard({
+  category,
+  recipeCount,
+  previewImageUrl,
+}: CategoryCardProps) {
+  const isComingSoon = recipeCount === 0;
+
+  const cardContent = (
+    <article className="relative">
+      <div className="relative aspect-[3/2] w-full overflow-hidden bg-gray-100">
+        {previewImageUrl ? (
+          <Image
+            src={getContentfulImageSrc(previewImageUrl, IMAGE_TRANSFORMS.cardThumb)}
+            alt={`${category.label} recipes`}
+            fill
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
+            className="object-cover transition-transform duration-300 group-hover:scale-110"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-gray-400">
+            <svg
+              className="h-12 w-12"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+          </div>
+        )}
+
+        {/* COMING SOON overlay - only covers image section */}
+        {isComingSoon && (
+          <div
+            className="absolute inset-0 bg-black/40 flex items-center justify-center backdrop-blur-sm"
+            role="status"
+            aria-label="Coming soon - No recipes available yet"
+          >
+            <div className="text-center">
+              <p className="text-white text-2xl font-bold tracking-wide">
+                COMING SOON
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="relative p-4 bg-white">
+        <h2 className="text-lg font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
+          {category.label}
+        </h2>
+        <p className="mt-1 text-sm text-gray-600">{category.blurb}</p>
+
+        {!isComingSoon && (
+          <div className="absolute right-4 top-4 rounded-full bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700">
+            {recipeCount} {recipeCount === 1 ? "recipe" : "recipes"}
+          </div>
+        )}
+      </div>
+
+      {!isComingSoon && (
+        <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
+      )}
+    </article>
+  );
+
+  if (isComingSoon) {
+    return (
+      <div
+        className="group block overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm cursor-not-allowed opacity-75"
+        aria-disabled="true"
+        aria-label={`${category.label} - Coming soon, no recipes available yet`}
+      >
+        {cardContent}
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      href={`/cookbook/${category.slug}`}
+      className="group block overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition-all duration-300 hover:shadow-xl hover:scale-105 hover:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+    >
+      {cardContent}
+    </Link>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -46,6 +46,7 @@ export default function Header() {
     { href: "/", label: "Home" },
     { href: "/cv", label: "CV" },
     { href: "/travel", label: "Travel" },
+    { href: "/cookbook", label: "Cookbook" },
     { href: "/photo-of-the-day", label: "Daily Photo" },
   ];
 

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -1,0 +1,88 @@
+import Image from "next/image";
+import Link from "next/link";
+import { RecipeSkeleton } from "@/types/contentful";
+import { getContentfulImageSrc, IMAGE_TRANSFORMS } from "@/lib/images";
+import { Asset, Entry } from "contentful";
+
+interface RecipeCardProps {
+  recipe: Entry<RecipeSkeleton>;
+  categorySlug: string;
+}
+
+export default function RecipeCard({ recipe, categorySlug }: RecipeCardProps) {
+  const title = recipe.fields.title as unknown as string;
+  const slug = recipe.fields.slug as unknown as string;
+  const description = recipe.fields.description as unknown as string | undefined;
+  const image = recipe.fields.image as unknown as Asset | undefined;
+  const servings = recipe.fields.servings as unknown as number | undefined;
+  const prep = recipe.fields.prepTimeMinutes as unknown as number | undefined;
+  const cook = recipe.fields.cookTimeMinutes as unknown as number | undefined;
+  const totalMinutes = (prep ?? 0) + (cook ?? 0);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const imageUrl = (image?.fields as any)?.file?.url as string | undefined;
+
+  return (
+    <Link
+      href={`/cookbook/${categorySlug}/${slug}`}
+      className="group block overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition-all duration-300 hover:shadow-xl hover:scale-105 hover:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+    >
+      <article className="relative">
+        {/* Recipe photos are 3:2 landscape and render uncropped in this frame
+            (deliberately not CityCard's 4:3 — see cookbook-routes-and-ui ticket). */}
+        <div className="relative aspect-[3/2] w-full overflow-hidden bg-gray-100">
+          {imageUrl ? (
+            <Image
+              src={getContentfulImageSrc(imageUrl, IMAGE_TRANSFORMS.cardThumb)}
+              alt={`Photo of ${title}`}
+              fill
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              className="object-cover transition-transform duration-300 group-hover:scale-110"
+              loading="lazy"
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center text-gray-400">
+              <svg
+                className="h-12 w-12"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+            </div>
+          )}
+        </div>
+
+        <div className="p-4 bg-white">
+          <h2 className="text-lg font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
+            {title}
+          </h2>
+          {description && (
+            <p className="mt-1 text-sm text-gray-600 line-clamp-2">{description}</p>
+          )}
+          {(totalMinutes > 0 || servings) && (
+            <p className="mt-2 text-xs font-medium text-gray-500">
+              {totalMinutes > 0 && <span>{totalMinutes} min</span>}
+              {totalMinutes > 0 && servings && <span aria-hidden="true"> · </span>}
+              {servings && (
+                <span>
+                  Serves {servings}
+                </span>
+              )}
+            </p>
+          )}
+        </div>
+
+        {/* Hover overlay effect */}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
+      </article>
+    </Link>
+  );
+}

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -218,11 +218,12 @@ describe("Header Component", () => {
       expect(mobileMenu).toBeInTheDocument();
 
       const links = mobileMenu!.querySelectorAll("a");
-      expect(links).toHaveLength(4);
+      expect(links).toHaveLength(5);
       expect(links[0]).toHaveTextContent("Home");
       expect(links[1]).toHaveTextContent("CV");
       expect(links[2]).toHaveTextContent("Travel");
-      expect(links[3]).toHaveTextContent("Daily Photo");
+      expect(links[3]).toHaveTextContent("Cookbook");
+      expect(links[4]).toHaveTextContent("Daily Photo");
     });
   });
 

--- a/src/components/__tests__/RecipeCard.test.tsx
+++ b/src/components/__tests__/RecipeCard.test.tsx
@@ -1,0 +1,116 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen } from "@testing-library/react";
+import RecipeCard from "../RecipeCard";
+import { Entry } from "contentful";
+import { RecipeSkeleton } from "@/types/contentful";
+import React from "react";
+
+// Mock Next.js Image component
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props;
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...rest} data-fill={fill ? "true" : "false"} />;
+  },
+}));
+
+// Mock Next.js Link component
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    className,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+function mockRecipe(
+  overrides: Record<string, unknown> = {}
+): Entry<RecipeSkeleton> {
+  return {
+    sys: { id: "recipe-1" },
+    fields: {
+      title: "Asparagus, Pea & Pancetta Pasta",
+      slug: "asparagus-pea-and-pancetta-pasta",
+      category: "mains",
+      description: "A speedy midweek dinner with a creamy lemon sauce.",
+      image: {
+        fields: {
+          file: { url: "//images.ctfassets.net/space/recipe.jpg" },
+        },
+      },
+      ingredients: "175g pasta",
+      method: "Cook it.",
+      servings: 2,
+      prepTimeMinutes: 10,
+      cookTimeMinutes: 15,
+      ...overrides,
+    },
+  } as unknown as Entry<RecipeSkeleton>;
+}
+
+describe("RecipeCard", () => {
+  it("links to the recipe page under its category", () => {
+    render(<RecipeCard recipe={mockRecipe()} categorySlug="mains" />);
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "/cookbook/mains/asparagus-pea-and-pancetta-pasta"
+    );
+  });
+
+  it("renders title, description teaser and meta line", () => {
+    render(<RecipeCard recipe={mockRecipe()} categorySlug="mains" />);
+    expect(
+      screen.getByRole("heading", { name: "Asparagus, Pea & Pancetta Pasta" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("A speedy midweek dinner with a creamy lemon sauce.")
+    ).toBeInTheDocument();
+    // 10 prep + 15 cook
+    expect(screen.getByText("25 min")).toBeInTheDocument();
+    expect(screen.getByText("Serves 2")).toBeInTheDocument();
+  });
+
+  it("renders the photo uncropped in a 3:2 frame", () => {
+    const { container } = render(
+      <RecipeCard recipe={mockRecipe()} categorySlug="mains" />
+    );
+    expect(container.querySelector(".aspect-\\[3\\/2\\]")).toBeInTheDocument();
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "alt",
+      "Photo of Asparagus, Pea & Pancetta Pasta"
+    );
+  });
+
+  it("renders a placeholder when the recipe has no image", () => {
+    render(
+      <RecipeCard recipe={mockRecipe({ image: undefined })} categorySlug="mains" />
+    );
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("omits the meta line when servings and times are absent", () => {
+    render(
+      <RecipeCard
+        recipe={mockRecipe({
+          servings: undefined,
+          prepTimeMinutes: undefined,
+          cookTimeMinutes: undefined,
+        })}
+        categorySlug="mains"
+      />
+    );
+    expect(screen.queryByText(/min/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Serves/)).not.toBeInTheDocument();
+  });
+});

--- a/src/lib/__tests__/cookbook.test.ts
+++ b/src/lib/__tests__/cookbook.test.ts
@@ -1,0 +1,134 @@
+import { Entry, EntryCollection } from "contentful";
+import {
+  CATEGORIES,
+  getAllRecipes,
+  getCategory,
+  recipesInCategory,
+  splitIngredients,
+  splitMethodSteps,
+} from "../cookbook";
+import * as contentful from "@/lib/contentful";
+import { RecipeSkeleton } from "@/types/contentful";
+
+jest.mock("@/lib/contentful");
+
+const mockGetEntriesByType = contentful.getEntriesByType as jest.MockedFunction<
+  typeof contentful.getEntriesByType
+>;
+
+function mockRecipe(slug: string, category: string): Entry<RecipeSkeleton> {
+  return {
+    sys: { id: `id-${slug}` },
+    fields: {
+      title: slug,
+      slug,
+      category,
+      ingredients: "a\nb",
+      method: "step one\n\nstep two",
+    },
+  } as unknown as Entry<RecipeSkeleton>;
+}
+
+function asCollection(
+  items: Entry<RecipeSkeleton>[]
+): EntryCollection<RecipeSkeleton> {
+  return {
+    items,
+    total: items.length,
+    skip: 0,
+    limit: 100,
+    sys: { type: "Array" },
+  } as unknown as EntryCollection<RecipeSkeleton>;
+}
+
+describe("CATEGORIES / getCategory", () => {
+  it("defines the four fixed categories in display order", () => {
+    expect(CATEGORIES.map((c) => c.slug)).toEqual([
+      "mains",
+      "sides",
+      "snacks",
+      "desserts",
+    ]);
+  });
+
+  it("looks up a category by slug", () => {
+    expect(getCategory("desserts")?.label).toBe("Desserts");
+  });
+
+  it("returns undefined for an unknown slug", () => {
+    expect(getCategory("starters")).toBeUndefined();
+  });
+});
+
+describe("getAllRecipes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns recipes with recognised categories", async () => {
+    mockGetEntriesByType.mockResolvedValue(
+      asCollection([mockRecipe("lasagne", "mains"), mockRecipe("flapjack", "snacks")])
+    );
+
+    const recipes = await getAllRecipes();
+    expect(recipes).toHaveLength(2);
+  });
+
+  it("skips recipes with an unknown category and warns", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    mockGetEntriesByType.mockResolvedValue(
+      asCollection([mockRecipe("lasagne", "mains"), mockRecipe("mystery", "brunch")])
+    );
+
+    const recipes = await getAllRecipes();
+    expect(recipes).toHaveLength(1);
+    expect(recipes[0].fields.slug).toBe("lasagne");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('unknown category "brunch"')
+    );
+    warnSpy.mockRestore();
+  });
+});
+
+describe("recipesInCategory", () => {
+  it("partitions recipes by category", () => {
+    const recipes = [
+      mockRecipe("lasagne", "mains"),
+      mockRecipe("flapjack", "snacks"),
+      mockRecipe("carbonara", "mains"),
+    ];
+
+    expect(recipesInCategory(recipes, "mains").map((r) => r.fields.slug)).toEqual([
+      "lasagne",
+      "carbonara",
+    ]);
+    expect(recipesInCategory(recipes, "desserts")).toEqual([]);
+  });
+});
+
+describe("splitIngredients", () => {
+  it("splits one ingredient per line, dropping blanks and whitespace", () => {
+    expect(splitIngredients("175g pasta\n  1 tsp olive oil  \n\n50g pancetta\n")).toEqual([
+      "175g pasta",
+      "1 tsp olive oil",
+      "50g pancetta",
+    ]);
+  });
+});
+
+describe("splitMethodSteps", () => {
+  it("splits steps on blank lines and unwraps internal newlines", () => {
+    const method = "Boil the pasta\nuntil al dente.\n\nFry the pancetta.";
+    expect(splitMethodSteps(method)).toEqual([
+      "Boil the pasta until al dente.",
+      "Fry the pancetta.",
+    ]);
+  });
+
+  it("falls back to one step per line when there are no blank lines", () => {
+    expect(splitMethodSteps("Boil the pasta.\nFry the pancetta.")).toEqual([
+      "Boil the pasta.",
+      "Fry the pancetta.",
+    ]);
+  });
+});

--- a/src/lib/cookbook.ts
+++ b/src/lib/cookbook.ts
@@ -1,0 +1,102 @@
+import { Entry } from "contentful";
+import { getEntriesByType } from "@/lib/contentful";
+import { RecipeCategory, RecipeSkeleton } from "@/types/contentful";
+
+/**
+ * Cookbook category configuration.
+ *
+ * Categories are deliberately NOT a Contentful content type: the list is small
+ * and stable, so recipes carry a validated `category` dropdown and the pages
+ * (labels, blurbs, ordering) are defined here. This avoids managing category
+ * entries and the orphaned-reference failure mode travel hit with countries.
+ */
+export interface CategoryConfig {
+  slug: RecipeCategory;
+  label: string;
+  blurb: string;
+}
+
+export const CATEGORIES: readonly CategoryConfig[] = [
+  {
+    slug: "mains",
+    label: "Mains",
+    blurb: "Proper dinners — the dishes that anchor the plate.",
+  },
+  {
+    slug: "sides",
+    label: "Sides",
+    blurb: "Supporting acts that sometimes steal the show.",
+  },
+  {
+    slug: "snacks",
+    label: "Snacks",
+    blurb: "Small plates and between-meal fixes.",
+  },
+  {
+    slug: "desserts",
+    label: "Desserts",
+    blurb: "The sweet finish.",
+  },
+];
+
+const VALID_CATEGORY_SLUGS = new Set<string>(CATEGORIES.map((c) => c.slug));
+
+export function getCategory(slug: string): CategoryConfig | undefined {
+  return CATEGORIES.find((c) => c.slug === slug);
+}
+
+/**
+ * All recipes with a recognised category, sorted by title.
+ *
+ * A recipe whose `category` value isn't one of the configured slugs shouldn't
+ * exist (Contentful validates the field), but if one slips through it is
+ * skipped with a build-time warning rather than breaking the export — same
+ * spirit as the orphaned-country guard on the homepage.
+ */
+export async function getAllRecipes(): Promise<Entry<RecipeSkeleton>[]> {
+  const recipes = await getEntriesByType<RecipeSkeleton>("recipe", {
+    order: ["fields.title"],
+  });
+
+  return recipes.items.filter((recipe) => {
+    const category = recipe.fields.category as unknown as string;
+    if (!VALID_CATEGORY_SLUGS.has(category)) {
+      console.warn(
+        `Skipping recipe "${recipe.fields.slug}" — unknown category "${category}"`
+      );
+      return false;
+    }
+    return true;
+  });
+}
+
+export function recipesInCategory(
+  recipes: Entry<RecipeSkeleton>[],
+  categorySlug: string
+): Entry<RecipeSkeleton>[] {
+  return recipes.filter(
+    (recipe) => (recipe.fields.category as unknown as string) === categorySlug
+  );
+}
+
+/** One ingredient per line → list items. */
+export function splitIngredients(text: string): string[] {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+/**
+ * One step per paragraph (blank-line separated) → numbered steps.
+ * Falls back to one step per line when there are no blank lines, so
+ * single-newline-separated content still renders sensibly.
+ */
+export function splitMethodSteps(text: string): string[] {
+  const paragraphs = text
+    .split(/\n\s*\n/)
+    .map((p) => p.replace(/\s*\n\s*/g, " ").trim())
+    .filter(Boolean);
+  if (paragraphs.length > 1) return paragraphs;
+  return splitIngredients(text);
+}

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -47,6 +47,8 @@ export const IMAGE_TRANSFORMS = {
   galleryThumb: { width: 800, quality: 60, format: "webp" },
   galleryFull: { quality: 82, format: "webp" },
   avatar: { width: 400, format: "webp" },
+  // Recipe detail hero: displayed at max-w-3xl (768px), so 1536 = 2× retina.
+  recipeHero: { width: 1536, quality: 75, format: "webp" },
 } as const satisfies Record<string, ImageTransform>;
 
 function withTransform(url: string, transform?: ImageTransform): string {

--- a/src/types/contentful.ts
+++ b/src/types/contentful.ts
@@ -44,6 +44,28 @@ export interface PhotoFields {
 
 export type PhotoSkeleton = EntrySkeletonType<PhotoFields, "photo">;
 
+// Recipe Content Type
+// Categories are a fixed dropdown on the entry (validated in Contentful);
+// category pages are defined in code — see src/lib/cookbook.ts.
+export type RecipeCategory = "mains" | "sides" | "snacks" | "desserts";
+
+export interface RecipeFields {
+  title: string;
+  slug: string;
+  category: RecipeCategory;
+  description?: string;
+  image?: Asset;
+  /** One ingredient per line */
+  ingredients: string;
+  /** One step per paragraph (blank-line separated) */
+  method: string;
+  servings?: number;
+  prepTimeMinutes?: number;
+  cookTimeMinutes?: number;
+}
+
+export type RecipeSkeleton = EntrySkeletonType<RecipeFields, "recipe">;
+
 // Page Content Type
 export interface PageFields {
   title: string;

--- a/tickets/cookbook-recipe-content-model.md
+++ b/tickets/cookbook-recipe-content-model.md
@@ -1,0 +1,75 @@
+# Cookbook: create the `recipe` content model in Contentful
+
+**Type:** Task · **Status:** To Do · **Area:** Contentful / content model · **Blocks:** `cookbook-routes-and-ui.md`
+
+## Objective
+
+Add a `recipe` content type to Contentful so the site can serve a cookbook section
+(`/cookbook`) organised into four fixed categories: **Mains, Sides, Snacks, Desserts**.
+
+Categories are deliberately **not** a separate content type. Unlike countries→cities
+(both open-ended), the category list is small and stable, so it lives as a validated
+dropdown field on `recipe`. Category pages (labels, blurbs, ordering) are defined in
+code. This avoids extra entries to manage and the orphaned-reference failure mode that
+breaks the city-route build when a referenced entry is unpublished.
+
+## Content model
+
+Content type ID `recipe`, display field `title`:
+
+| Field | ID | Type | Required | Notes |
+|-------|----|------|----------|-------|
+| Title | `title` | Symbol | Yes | Recipe name |
+| Slug | `slug` | Symbol | Yes | **Unique**, kebab-case; drives the static route |
+| Category | `category` | Symbol | Yes | Dropdown validated to exactly: `mains`, `sides`, `snacks`, `desserts` (lowercase slugs — no mapping needed for routing; display labels live in code) |
+| Description | `description` | Long text | No | Short teaser shown on cards and at the top of the detail page |
+| Image | `image` | Asset | No | Hero photo (1920px width, same guidance as travel photos). Cards fall back to a placeholder when absent |
+| Ingredients | `ingredients` | Long text | Yes | One ingredient per line; rendered as a list |
+| Method | `method` | Long text | Yes | One step per paragraph/line; rendered as numbered steps |
+| Servings | `servings` | Integer | No | |
+| Prep time | `prepTimeMinutes` | Integer | No | Minutes |
+| Cook time | `cookTimeMinutes` | Integer | No | Minutes |
+
+Created programmatically via `scripts/create-recipe-content-type.mjs` (idempotent,
+`--dry-run` supported) using the CMA token already in `.env.local`.
+
+**No new credentials:** the existing Content Delivery API token covers new content
+types automatically; nothing changes in `.env.local` or the deploy workflow.
+
+## Code/docs changes (this ticket)
+
+- `src/types/contentful.ts` — add `RecipeFields` / `RecipeSkeleton`
+  (`EntrySkeletonType<RecipeFields, "recipe">`), with `category` typed as the
+  union `"mains" | "sides" | "snacks" | "desserts"`.
+- `CONTENTFUL.md` — add the `recipe` table to the Content Models section, including
+  the fixed category values and the "categories are code-defined" rationale.
+
+## Seed content
+
+- Create and **publish** at least one recipe per category so every category page has
+  content to render during the routes ticket.
+
+## Acceptance Criteria
+
+- [x] `recipe` content type exists in Contentful with the fields/validations above
+      (created via `scripts/create-recipe-content-type.mjs`).
+- [x] `slug` is unique; `category` only accepts the four fixed values.
+- [ ] At least one published recipe in each of the four categories.
+      (2 published in `mains`; `sides`/`snacks`/`desserts` still to seed —
+      candidates in `~/repos/personal/assistant/recipes/`.)
+- [x] `RecipeFields` / `RecipeSkeleton` added to `src/types/contentful.ts`.
+- [x] `CONTENTFUL.md` documents the new model.
+- [x] `npm run lint`, type-check, and tests pass (pre-push hook).
+
+## Notes
+
+- **Why not rich text** for ingredients/method: long text with line-based rendering is
+  the simplest thing that works and matches how travel content avoids rich-text
+  complexity; can migrate to rich text later if formatting needs grow.
+- The type was created with `scripts/create-recipe-content-type.mjs`. Note that
+  `contentful-management` v12 uses the plain client API (no default export /
+  `getSpace` chaining) — `create-locations.mjs` and `upload-to-contentful.mjs`
+  have been migrated to it (read paths verified by dry-run; write paths get their
+  first real exercise on the next upload).
+- Out of scope: all site routes/UI (see `cookbook-routes-and-ui.md`), homepage
+  cookbook teaser, any changes to travel content types.

--- a/tickets/cookbook-routes-and-ui.md
+++ b/tickets/cookbook-routes-and-ui.md
@@ -1,0 +1,104 @@
+# Cookbook: add /cookbook routes and UI
+
+**Type:** Task · **Status:** To Do · **Area:** `src/app/cookbook` · **Depends on:** `cookbook-recipe-content-model.md`
+
+## Objective
+
+Add a statically-exported cookbook section mirroring the travel layout:
+
+```
+/cookbook                          — 4 category cards (Mains, Sides, Snacks, Desserts)
+/cookbook/[categorySlug]           — recipe cards for that category
+/cookbook/[categorySlug]/[recipeSlug] — recipe detail page
+```
+
+## Background / current state
+
+- Travel provides the pattern to copy: `src/app/travel/page.tsx` (index of
+  `CountryCard`s) → `travel/[countrySlug]/page.tsx` (grid of `CityCard`s, uses
+  `generateStaticParams`) → `travel/[countrySlug]/[citySlug]/page.tsx` (detail).
+- Categories are **code-defined** (see the model ticket): recipes carry a validated
+  `category` field with values `mains | sides | snacks | desserts`; there is no
+  category content type.
+- Data access via the existing `getEntriesByType` helper in `src/lib/contentful.ts`;
+  types come from `RecipeSkeleton` (added by the model ticket).
+- Site is static-exported: one fetch of all recipes at build time, partitioned by
+  category in code.
+
+## Technical Specifications
+
+### Category config (code)
+
+A single `CATEGORIES` const (e.g. `src/lib/cookbook.ts`) drives everything:
+
+```ts
+export const CATEGORIES = [
+  { slug: "mains", label: "Mains", blurb: "..." },
+  { slug: "sides", label: "Sides", blurb: "..." },
+  { slug: "snacks", label: "Snacks", blurb: "..." },
+  { slug: "desserts", label: "Desserts", blurb: "..." },
+] as const;
+```
+
+- `/cookbook` renders one card per entry, in this order, each showing its recipe count
+  and a preview image (first recipe's image in that category, else placeholder).
+- Both dynamic segments use `generateStaticParams`: categories from `CATEGORIES`,
+  recipes from the fetched entries.
+
+### Pages
+
+- **`/cookbook`** — heading + 4 category cards. Follow the `/travel` index structure;
+  a category with zero recipes still renders its card (styled like the coming-soon
+  treatment on `CityCard`).
+- **`/cookbook/[categorySlug]`** — `Breadcrumb`, category heading + blurb, grid of
+  recipe cards (image, title, description teaser, prep+cook time when present).
+  Empty state: "Recipes coming soon" line, matching the homepage Latest empty-state tone.
+  Unknown category slugs 404 (`notFound()`); only the four configured slugs are
+  generated.
+- **`/cookbook/[categorySlug]/[recipeSlug]`** — `Breadcrumb`, hero image (when
+  present), title, description, meta row (servings / prep / cook, hiding absent
+  values), **Ingredients** as a bulleted list (split `ingredients` on newlines),
+  **Method** as numbered steps (split `method` on blank lines/newlines). Recipes whose
+  `category` value doesn't match the route's category 404.
+  - Layout is a constrained reading column: hero capped at `max-w-3xl` (~768px), not
+    full-bleed — recipe photos are 1536px wide, which is exactly 2× retina-sharp at
+    that width; the Images API can only downscale.
+
+### Components
+
+- `RecipeCard` — new, modelled on `CityCard` (image/placeholder, title, teaser, meta),
+  **but with an `aspect-[3/2]` image frame, not CityCard's `aspect-[4/3]`** — recipe
+  photos are shot/exported at 3:2 and should render uncropped on cards. `CityCard`
+  and all travel rendering are untouched. Convention: recipe photos are landscape 3:2
+  (any other ratio gets cropped to the 3:2 frame).
+- Category cards: reuse/adapt `CountryCard` styling; a small `CategoryCard` is fine if
+  reuse gets awkward.
+
+### Site chrome
+
+- `Header.tsx` — add a "Cookbook" nav link alongside CV / Travel.
+- `src/app/sitemap.ts` — include `/cookbook`, category pages, and recipe pages.
+- Page metadata (`generateMetadata`) per page, following the travel pages.
+
+## Acceptance Criteria
+
+- [x] `/cookbook` renders 4 category cards in the configured order with recipe counts.
+- [x] Category pages list only that category's recipes; empty categories show the
+      "Recipes coming soon" state instead of a bare grid.
+- [x] Recipe pages render ingredients as a list and method as numbered steps; absent
+      optional fields (image, servings, times, description) render cleanly.
+- [x] Unknown category or recipe slugs 404; `npm run build` statically generates all
+      cookbook routes (trailing-slash export, resolvable on S3).
+- [x] "Cookbook" appears in the header nav; cookbook URLs appear in the sitemap.
+- [x] Unit tests cover: category partitioning, empty-category state, ingredient/method
+      line splitting, and 404 on bad slugs.
+- [x] `npm run lint`, type-check, and tests pass (pre-push hook).
+
+## Notes
+
+- **Out of scope:** homepage "Latest recipes" teaser (revisit once the section is
+  live), search integration (`SearchBox` covers travel only), any Contentful model
+  changes, photo-upload tooling for recipes.
+- Build guard: a recipe with an unexpected `category` value (shouldn't happen given
+  the dropdown validation) is skipped with a build-time warning rather than breaking
+  the export — same spirit as the orphaned-country guard on the homepage.


### PR DESCRIPTION
## Summary

Adds the cookbook section (tickets `cookbook-recipe-content-model.md` + `cookbook-routes-and-ui.md`): a `recipe` Contentful content type, the `/cookbook` routes mirroring the travel layout, and the tooling around it. Also migrates the existing CMA scripts to contentful-management v12, which had silently broken them.

Categories (Mains / Sides / Snacks / Desserts) are deliberately **not** a content type — recipes carry a validated dropdown and the category pages are defined in code (`src/lib/cookbook.ts`), avoiding the orphaned-reference failure mode travel hit with countries.

## Changes

- **Content model tooling**: `scripts/create-recipe-content-type.mjs` creates/publishes the `recipe` type idempotently (already run against the live space; 2 recipes published in Mains).
- **Routes**: `/cookbook` (category cards with counts / coming-soon), `/cookbook/[categorySlug]` (recipe grid + "Recipes coming soon" empty state), `/cookbook/[categorySlug]/[recipeSlug]` (reading-column detail page with Recipe JSON-LD). Unknown slugs 404; recipes with an unrecognised category are skipped with a build warning rather than breaking the export.
- **Components**: `RecipeCard` (3:2 image frame so recipe photos render uncropped — CityCard's 4:3 untouched), `CategoryCard`. New `recipeHero` image transform (1536px = 2× retina at the detail page's `max-w-3xl` hero).
- **v12 CMA migration**: `create-locations.mjs` + `upload-to-contentful.mjs` moved to the plain-client API (v11 chained client removed upstream — both were broken since the dependency bump in #60). Read paths verified by dry-run against the live space; write paths exercised for real publishing the two seed recipes.
- **Chrome**: Cookbook in header nav (desktop + mobile), cookbook URLs in the sitemap, `CONTENTFUL.md` documents the model and photo workflow.

## Tests

- 30 new tests (817 total, all green): cookbook lib (category partitioning, unknown-category guard, ingredient/method splitting), RecipeCard, and all three pages (empty-category state, 404 on bad category/recipe slugs, category-mismatch 404).
- Full static export build verified: all 4 category pages + recipe pages generate; routes smoke-tested over a local static server (200s + 404 on bogus slugs) and visually checked desktop + mobile.

## Notes

- Seeding one recipe into each remaining category (sides/snacks/desserts) is the one open AC on the content-model ticket — candidates live in `~/repos/personal/assistant/recipes/`.
- Site deploy remains manual (GitHub Actions `workflow_dispatch`); merging this does not publish the cookbook until a deploy is run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)