### PR TITLE
Hosting security: headers, www redirect, and OAC hardening (all findings closed)

### DIFF
--- a/tickets/add-security-headers.md
+++ b/tickets/add-security-headers.md
@@ -1,0 +1,60 @@
+# Add security response headers via CloudFront
+
+**Type:** Task · **Status:** To Do · **Area:** Hosting / infra · **Priority:** Low
+
+## Problem
+
+Responses from `maxharding4.com` carry **no security headers** — an external review
+found none of HSTS, Content-Security-Policy, X-Content-Type-Options, X-Frame-Options,
+Referrer-Policy, or Permissions-Policy.
+
+Impact is limited for a static, no-auth site, but one gap is worth closing:
+
+- **HSTS is missing.** There's an HTTP→HTTPS 301 redirect, but with no
+  `Strict-Transport-Security` header a first-time visitor's initial HTTP request can
+  still be intercepted (SSL-strip) before the redirect. HSTS tells browsers to go
+  straight to HTTPS on every subsequent visit.
+
+## Approach
+
+Add a **CloudFront response-headers-policy** to the distribution (a managed feature —
+no code, no rebuild). Suggested headers:
+
+| Header | Value | Why |
+|--------|-------|-----|
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | Force HTTPS. Add `preload` only once `www` is sorted (see `fix-www-subdomain.md`) and you're ready to commit. |
+| `X-Content-Type-Options` | `nosniff` | Stop MIME-sniffing. |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limit referrer leakage. |
+| `X-Frame-Options` | `DENY` | Anti-clickjacking (or use CSP `frame-ancestors`). |
+| `Content-Security-Policy` | start report-only, then enforce | Tightest control; needs tuning for the GA script + Contentful image CDN. |
+
+**CSP caveat:** the site loads Google Analytics and images from Contentful's CDN, so a
+strict CSP needs those origins allow-listed (`img-src`/`connect-src` for
+`images.ctfassets.net`, `script-src`/`connect-src` for the GA/gtag domains). Roll it
+out as `Content-Security-Policy-Report-Only` first, watch for violations, then switch
+to enforcing.
+
+## Dependency
+
+Best done **after** `harden-cloudfront-oac.md`. While the S3 website endpoint is
+publicly reachable, these headers can be bypassed by hitting S3 directly — private
+bucket + OAC is what guarantees all traffic actually goes through CloudFront and
+picks up the policy.
+
+## Acceptance Criteria
+
+- [x] CloudFront response-headers-policy attached to the distribution.
+      (`maxharding4-security-headers`, attached to the Default (*) behaviour on
+      distribution `E18D7W5LICE64E`, 2026-07-13.)
+- [x] `curl -sI https://maxharding4.com/` shows `Strict-Transport-Security` and
+      `X-Content-Type-Options` at minimum. (Also serving `X-Frame-Options: DENY`
+      and `Referrer-Policy: strict-origin-when-cross-origin`.)
+- [ ] CSP (if added) verified not to break GA or Contentful images — deployed
+      report-only first, then enforced. **Deferred** — CSP and HSTS `preload`
+      intentionally left off this first pass (CSP needs GA + Contentful-CDN
+      tuning; `preload` waits until `www` is fixed). Optional follow-up.
+
+## Notes
+
+- Low priority; HSTS is the highest-value item in the list.
+- Found by the external security assessment on 2026-07-13.

--- a/tickets/custom-404-page.md
+++ b/tickets/custom-404-page.md
@@ -1,0 +1,40 @@
+# Design a custom, on-brand 404 page
+
+**Type:** Task · **Status:** To Do · **Area:** Frontend (`src/app/`) · **Priority:** Low
+
+## Objective
+
+Replace the generic Next.js 404 body with a bespoke, on-brand not-found page that
+helps a lost visitor get back into the site.
+
+## Current state (2026-07-13)
+
+- No `src/app/not-found.tsx` exists — the site uses Next's App Router **default 404**.
+- The generated `/404.html` **already carries full site chrome** (header, nav, footer,
+  fonts, background) because the root layout wraps it. So it's not unstyled — only the
+  middle message is generic: *"404 | This page could not be found."*
+- CloudFront now serves this `/404.html` for `403`/`404` errors (custom error
+  responses added during the OAC hardening), so a missing page shows the site-styled
+  404 rather than a raw S3 error. **The plumbing is done; this ticket is purely the
+  design/copy of the message body.**
+
+## Scope
+
+- Add `src/app/not-found.tsx` — a styled component rendered inside the existing layout.
+- Content ideas: a friendly headline, a short line of copy, and clear links back into
+  the site (Home, Travel gallery, Cookbook). Consider a relevant image/illustration.
+- Keep it consistent with the existing page styling (Tailwind, the `heading-hero` /
+  `page-canvas` conventions used elsewhere).
+
+## Acceptance Criteria
+
+- [ ] `src/app/not-found.tsx` renders a custom 404 with navigation back into the site.
+- [ ] `/404.html` in the static export shows the new content (still wrapped in site chrome).
+- [ ] A missing URL on the live site (e.g. `/nope/`) shows the styled page and returns
+      HTTP 404 (CloudFront error responses already map 403/404 → `/404.html`).
+- [ ] `npm run lint`, type-check, and tests pass.
+
+## Notes
+
+- Small, self-contained frontend change — needs a rebuild + manual deploy to go live.
+- No infra changes required; the CloudFront custom error responses are already in place.

--- a/tickets/fix-www-subdomain.md
+++ b/tickets/fix-www-subdomain.md
@@ -1,0 +1,73 @@
+# Fix www.maxharding4.com — broken, possible subdomain-takeover vector
+
+**Type:** Task · **Status:** To Do · **Area:** Hosting / DNS · **Priority:** Medium
+
+## Problem
+
+`www.maxharding4.com` is misconfigured. It resolves (to CloudFront IPs, valid cert)
+but every request returns an S3 error:
+
+```
+HTTP/2 404
+x-amz-error-code: NoSuchBucket
+x-amz-error-message: The specified bucket does not exist
+x-amz-error-detail-bucketname: www.maxharding4.com
+```
+
+So `www` is routed to S3 by the bucket name `www.maxharding4.com`, and that bucket
+doesn't exist. Two issues:
+
+1. **It's broken.** Visitors typing `www.` get an S3 error page instead of the site.
+   The apex `maxharding4.com` works fine; `www` should redirect to it.
+2. **Potential subdomain takeover.** S3 bucket names are a single global namespace,
+   so `www.maxharding4.com` is claimable by anyone. If the `www` routing resolves by
+   bucket name (the `NoSuchBucket`/`bucketname` error strongly implies it does), an
+   attacker who creates that bucket could serve arbitrary content under
+   `www.maxharding4.com` — phishing/brand abuse under a subdomain that looks like yours.
+
+## Investigate first (AWS console)
+
+The apex is fronted by CloudFront with a cert valid for `www` too, so the exact
+`www` path isn't fully determinable from outside. Before changing anything, confirm
+in the console:
+
+- Route 53 (or wherever DNS lives): what does the `www` record point to — a
+  CloudFront distribution, or an S3 website endpoint directly?
+- CloudFront: is `www.maxharding4.com` an alternate domain name (CNAME) on the apex
+  distribution, or a separate distribution? What origin does it use?
+
+That determines which fix below applies.
+
+## Fix (pick per findings)
+
+- **If `www` isn't wanted at all:** delete the `www` DNS record. Simplest; removes
+  the takeover surface entirely.
+- **If `www` should redirect to apex (recommended):** create an S3 bucket named
+  `www.maxharding4.com` configured for **redirect all requests** to
+  `https://maxharding4.com`, and point `www` at it (or add `www` as a CloudFront
+  alias with a redirect function). Creating the bucket yourself also removes the
+  takeover risk, since the name is then owned.
+- Either way, once the OAC hardening lands (`harden-cloudfront-oac.md`), keep the
+  `www` handling consistent with the private-bucket model.
+
+## Acceptance Criteria
+
+- [x] Confirmed in-console how `www` is currently routed (DNS target + CloudFront config).
+      `www` A/AAAA alias → a **separate** CloudFront distribution `d22txfdj4mne1w`
+      whose origin was `www.maxharding4.com.s3-website.eu-west-2.amazonaws.com` — a
+      bucket that didn't exist (hence `NoSuchBucket`).
+- [x] `https://www.maxharding4.com/` 301-redirects to `https://maxharding4.com/`
+      (path preserved: `/cookbook/` → `/cookbook/`). No more `NoSuchBucket` page.
+- [x] No claimable S3 bucket name is left dangling. **Fixed 2026-07-13** by creating
+      the `www.maxharding4.com` bucket (eu-west-2) with static-website hosting set to
+      "redirect all requests to `maxharding4.com`, https". This both claims the name
+      (closing the takeover vector) and makes the existing distribution serve the
+      redirect — no DNS, cert, or distribution changes needed.
+
+**Status: Done.** Kept apex as canonical, `www` redirects (decided 2026-07-13).
+
+## Notes
+
+- Low urgency for the *broken* aspect (apex works), but the **takeover** aspect is
+  the reason this isn't purely cosmetic — worth closing sooner rather than later.
+- Found by the external security assessment on 2026-07-13.

--- a/tickets/harden-cloudfront-oac.md
+++ b/tickets/harden-cloudfront-oac.md
@@ -18,6 +18,22 @@ public access to the bucket and makes CloudFront the only way to reach the conte
 This is a standard, secure-enough setup for a public static site — but not the
 gold standard. This ticket is the hardening step, not urgent.
 
+### Confirmed by external assessment (2026-07-13)
+
+A passive external review confirmed two live consequences of the public bucket,
+both of which this ticket closes when the bucket goes private behind OAC:
+
+- **Anonymous object listing is enabled.** `https://s3.eu-west-2.amazonaws.com/maxharding4.com/?list-type=2`
+  returns a full object-key listing to unauthenticated callers — the public policy
+  grants `s3:ListBucket`, not just `s3:GetObject`. This lets anyone enumerate every
+  path/file, including anything not linked from the site. Even before the full OAC
+  migration, the public policy should drop `s3:ListBucket` (a static site needs only
+  `GetObject`); the OAC-scoped policy in this ticket removes public access entirely.
+- **Direct HTTP-only access.** Content is fetchable at
+  `http://maxharding4.com.s3-website.eu-west-2.amazonaws.com/` (plain HTTP, no TLS),
+  bypassing CloudFront and any protections added there (headers, WAF). Making the
+  bucket private is what forces all traffic through CloudFront/HTTPS.
+
 ## Target state
 
 - Bucket is **fully private** (Block Public Access fully on, public bucket policy removed).

--- a/tickets/harden-cloudfront-oac.md
+++ b/tickets/harden-cloudfront-oac.md
@@ -67,10 +67,32 @@ both of which this ticket closes when the bucket goes private behind OAC:
 
 ## Acceptance Criteria
 
-- [ ] Direct S3 object URLs return `AccessDenied`; the site is reachable only via CloudFront.
-- [ ] `maxharding4.com`, `/travel/`, city pages, `/cv/` all still return 200.
-- [ ] Block Public Access is fully enabled on the bucket.
-- [ ] Deploy pipeline (`aws s3 sync`) still works unchanged (it writes objects; OAC only affects reads).
+- [x] Direct S3 object URLs return `AccessDenied`; the site is reachable only via
+      CloudFront. (Verified 2026-07-13: anonymous listing, path-style GetObject, and
+      the S3 website endpoint all denied.)
+- [x] `maxharding4.com`, `/travel/`, city pages, `/cv/` all still return 200.
+- [x] Block Public Access is fully enabled on the bucket.
+- [ ] Deploy pipeline (`aws s3 sync`) still works unchanged (it writes objects; OAC only
+      affects reads). **Expected to work** — OAC/BPA only gate anonymous reads, not the
+      IAM-authenticated GitHub Actions writer — but **confirm on the next deploy**.
+
+**Status: Done** (2026-07-13), pending the next deploy to confirm the write path.
+
+## Implementation notes (as executed)
+
+Done live via the console in staged order, each stage verified externally before the next:
+
+1. **CloudFront Function** `directory-index-rewrite` (viewer-request) — rewrites `/x/` →
+   `/x/index.html` so the trailingSlash export resolves on the REST endpoint. Associated
+   on the Default (*) behaviour.
+2. **Origin → REST endpoint + OAC** — switched origin to
+   `maxharding4.com.s3.eu-west-2.amazonaws.com`, created OAC `maxharding4-oac` (sign
+   requests). Verified with the bucket still public (safe intermediate).
+3. **Custom error responses** — 403→`/404.html` and 404→`/404.html` (both return 404),
+   added *before* lock-down so private-bucket 403s surface the styled 404 page.
+4. **Lock-down** — replaced the public bucket policy with the OAC-scoped one above, then
+   enabled Block Public Access (all four). The public *listing* survived the policy swap
+   (it came from a public ACL, not the policy) and was closed by BPA's IgnorePublicAcls.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Documents an external security review of the live site (2026-07-13) and its remediation. **All four findings are now fixed** in the AWS console during paired sessions; this PR is the paper trail (ticket docs only — no code).

## Changes

- **`add-security-headers.md` (DONE)** — CloudFront response-headers policy on the apex distribution: HSTS, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`. CSP + HSTS `preload` deferred.
- **`fix-www-subdomain.md` (DONE)** — `www` was a separate orphaned distribution → non-existent bucket (`NoSuchBucket` + takeover vector). Fixed by creating the `www.maxharding4.com` redirect bucket → 301 to apex; claims the name, closes the vector.
- **`harden-cloudfront-oac.md` (DONE)** — bucket made private behind CloudFront OAC: directory-index CloudFront Function, origin switched to the S3 REST endpoint, 403/404→`/404.html` custom error responses, OAC-scoped bucket policy, and Block Public Access fully enabled. Closes the anonymous-listing and HTTP/S3-bypass findings. (Deploy write-path to confirm on next deploy.)
- **`custom-404-page.md` (new, DONE-adjacent)** — CloudFront now serves the site-styled `/404.html`; a bespoke 404 body remains as a small future frontend task.

## Verification

Every fix verified externally with `curl` (and a browser screenshot for the OAC change): headers present, `www`→apex 301, direct S3 access denied (`AccessDenied` on listing + GetObject, 403 on the website endpoint), site 200 through CloudFront, styled 404 preserved.

## Notes

- Docs only — no code paths touched.
- Site deploy remains manual; none of this required a redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)