### PR TITLE
Pre-warm image derivatives after publishing a recipe

### DIFF
--- a/CONTENTFUL.md
+++ b/CONTENTFUL.md
@@ -120,6 +120,11 @@ Behaviour:
   (`--slug` overrides the title-derived default). Warns when a photo isn't the
   3:2 card ratio.
 - **Idempotent** — an existing slug is reported and skipped, never overwritten.
+- **Pre-warms the image** — after publishing, it requests the card and hero
+  Images-API derivatives once so Contentful generates+caches them ahead of the
+  first real visitor (otherwise the first view after a deploy can briefly show a
+  broken image while the derivative is generated on demand). The warmed params
+  mirror `cardThumb`/`recipeHero` in `src/lib/images.ts`.
 - **Markdown `## Notes` are printed, not uploaded** (that's where personal
   context lives); fold anything worth keeping into the entry manually.
 - **`--servings` sets the field only** — it never rescales ingredient

--- a/scripts/create-recipe.mjs
+++ b/scripts/create-recipe.mjs
@@ -356,4 +356,29 @@ if (recipe.cookTimeMinutes) fields.cookTimeMinutes = { [LOCALE]: recipe.cookTime
 const entry = await cma.entry.create({ contentTypeId: "recipe" }, { fields });
 await cma.entry.publish({ entryId: entry.sys.id }, entry);
 console.log(`✔ Recipe entry published → ${entry.sys.id} (slug: ${slug}, category: ${opts.category})`);
+
+// Pre-warm the Contentful Images API derivatives the site will request, so the
+// first visitor after a deploy doesn't hit the on-the-fly generation lag (which
+// can briefly render a broken image). Params mirror the cardThumb and recipeHero
+// presets in src/lib/images.ts — keep them in sync. Best-effort: a warm failure
+// is non-fatal (the derivative just generates on first real request instead).
+const fileUrl = asset.fields?.file?.[LOCALE]?.url;
+if (fileUrl) {
+  const base = fileUrl.startsWith("http") ? fileUrl : `https:${fileUrl}`;
+  const derivatives = [
+    `${base}?w=600&q=55&fm=webp`, // cardThumb — recipe + category cards
+    `${base}?w=1536&q=75&fm=webp`, // recipeHero — detail page
+  ];
+  const results = await Promise.allSettled(derivatives.map((u) => fetch(u)));
+  const warmed = results.filter(
+    (r) => r.status === "fulfilled" && r.value.ok
+  ).length;
+  console.log(`🔥 Pre-warmed ${warmed}/${derivatives.length} image derivatives.`);
+}
+
 console.log(`\n💡 The site is static — run the deploy workflow to publish it.`);
+
+// Exit explicitly: the image pre-warm uses fetch (undici), whose keepalive
+// connection pool would otherwise keep the event loop alive after all the
+// awaited work is done. Everything above is complete at this point.
+process.exit(0);


### PR DESCRIPTION
## Summary

Fixes the brief broken-image flash a new recipe photo could show on first view after a deploy. Contentful's Images API generates transform derivatives (resize + webp) **on first request**, so whoever loads the page first hits the generation lag.

`scripts/create-recipe.mjs` now pre-warms the derivatives after publishing, so Contentful generates and caches them before any real visitor arrives.

## Changes

- After the recipe entry publishes, fetch the two derivatives the site requests — card (`w=600 q=55 fm=webp`) and hero (`w=1536 q=75 fm=webp`) — once each. Params mirror `cardThumb`/`recipeHero` in `src/lib/images.ts`.
- Best-effort: warm failures are non-fatal (the derivative just generates on first real request, as before).
- Adds an explicit `process.exit(0)` at the end — `fetch` (undici) keeps a keepalive connection pool open that would otherwise delay the CLI's exit after all awaited work is done.
- `CONTENTFUL.md` documents the behaviour.

## Tests

- Validated against a live asset: the published asset exposes `fields.file[locale].url`, and warming both derivatives returns 200 (`2/2`).
- Confirmed the fetch-then-exit pattern terminates in ~0.16s (vs a 2-min hang without the explicit exit).
- Quality gate green: lint, type-check, Jest (817).

## Notes

- Only affects new recipe publishes; no runtime/site code touched.
- Context: surfaced when a just-published recipe briefly showed a broken image on the live `/cookbook/mains/` page, then self-resolved once the derivative cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)